### PR TITLE
feat(toc): add configurable badge style (number/katakana/roman)

### DIFF
--- a/src/components/features/toc/FloatingTOC.astro
+++ b/src/components/features/toc/FloatingTOC.astro
@@ -7,6 +7,7 @@ import FloatingButton from "@components/common/FloatingButton.astro";
 import { siteConfig } from "../../../config";
 import I18nKey from "../../../i18n/i18nKey";
 import { i18n } from "../../../i18n/translation";
+import { normalizeTOCBadgeStyle } from "./utils/japanese-katakana";
 
 interface Props {
 	headings?: MarkdownHeading[];
@@ -14,13 +15,16 @@ interface Props {
 
 const { headings: _ = [] } = Astro.props;
 const tocDepth = siteConfig.toc.depth;
-const useJapaneseBadge = siteConfig.toc.useJapaneseBadge;
+const badgeStyle = normalizeTOCBadgeStyle(
+	siteConfig.toc.badgeStyle,
+	siteConfig.toc.useJapaneseBadge,
+);
 ---
 
 <div
 	class="floating-toc-wrapper"
 	data-depth={tocDepth}
-	data-japanese-badge={useJapaneseBadge}
+	data-badge-style={badgeStyle}
 >
 	<FloatingButton
 		id="floating-toc-btn"

--- a/src/components/features/toc/SidebarTOC.astro
+++ b/src/components/features/toc/SidebarTOC.astro
@@ -18,7 +18,7 @@ const { class: className } = Astro.props;
 </table-of-contents>
 
 <script>
-	import { JAPANESE_KATAKANA } from "./utils/japanese-katakana";
+	import { getTOCBadge } from "./utils/japanese-katakana";
 	import {
 		extractHeadings,
 		generateTOCItems,
@@ -299,11 +299,7 @@ const { class: className } = Astro.props;
 
 					let badgeContent: string;
 					if (item.depth === 0) {
-						badgeContent =
-							config.useJapaneseBadge &&
-							h1Count - 1 < JAPANESE_KATAKANA.length
-								? JAPANESE_KATAKANA[h1Count - 1]
-								: h1Count.toString();
+						badgeContent = getTOCBadge(h1Count - 1, config.badgeStyle);
 						h1Count++;
 					} else if (item.depth === 1) {
 						badgeContent =

--- a/src/components/features/toc/hooks/useMobileTOC.ts
+++ b/src/components/features/toc/hooks/useMobileTOC.ts
@@ -3,6 +3,12 @@
  * 处理移动端目录的状态管理和交互逻辑
  */
 
+import {
+	getTOCBadge,
+	normalizeTOCBadgeStyle,
+	type TOCBadgeStyle,
+} from "../utils/japanese-katakana";
+
 export interface TOCItem {
 	id: string;
 	text: string;
@@ -18,7 +24,7 @@ export interface PostItem {
 }
 
 export interface TOCConfig {
-	useJapaneseBadge: boolean;
+	badgeStyle: TOCBadgeStyle;
 	depth: number;
 }
 
@@ -26,29 +32,6 @@ export interface TOCConfig {
  * 生成目录项
  */
 export function generateTOCItems(config: TOCConfig): TOCItem[] {
-	const japaneseHiragana = [
-		"ア",
-		"イ",
-		"ウ",
-		"エ",
-		"オ",
-		"カ",
-		"キ",
-		"ク",
-		"ケ",
-		"コ",
-		"サ",
-		"シ",
-		"ス",
-		"セ",
-		"ソ",
-		"タ",
-		"チ",
-		"ツ",
-		"テ",
-		"ト",
-	];
-
 	const headings = document.querySelectorAll("h1, h2, h3, h4, h5, h6");
 	const items: TOCItem[] = [];
 	let h1Count = 0;
@@ -70,15 +53,8 @@ export function generateTOCItems(config: TOCConfig): TOCItem[] {
 
 		// 只为 H1 标题生成 badge
 		if (level === 1) {
+			badge = getTOCBadge(h1Count, config.badgeStyle);
 			h1Count++;
-			if (
-				config.useJapaneseBadge &&
-				h1Count - 1 < japaneseHiragana.length
-			) {
-				badge = japaneseHiragana[h1Count - 1];
-			} else {
-				badge = h1Count.toString();
-			}
 		}
 
 		items.push({ id: heading.id, text, level, badge });
@@ -166,8 +142,12 @@ export function scrollToHeading(id: string, offset = 80): void {
  * 获取 TOC 配置
  */
 export function getTOCConfig(): TOCConfig {
+	const badgeStyle = normalizeTOCBadgeStyle(
+		window.siteConfig?.toc?.badgeStyle,
+		window.siteConfig?.toc?.useJapaneseBadge,
+	);
 	return {
-		useJapaneseBadge: window.siteConfig?.toc?.useJapaneseBadge ?? false,
+		badgeStyle,
 		depth: window.siteConfig?.toc?.depth ?? 3,
 	};
 }

--- a/src/components/features/toc/hooks/useTocNavigation.ts
+++ b/src/components/features/toc/hooks/useTocNavigation.ts
@@ -4,6 +4,10 @@
  */
 
 import type { HeadingData, TOCScrollOptions } from "../types/toc";
+import {
+	normalizeTOCBadgeStyle,
+	type TOCBadgeStyle,
+} from "../utils/japanese-katakana";
 
 /**
  * 从 DOM 中提取标题数据
@@ -74,18 +78,28 @@ export function createHeadingClickHandler(
  */
 export function getTOCConfig(): {
 	depth: number;
+	badgeStyle: TOCBadgeStyle;
 	useJapaneseBadge: boolean;
 } {
 	const siteConfig = (
 		window as unknown as {
 			siteConfig?: {
-				toc?: { depth?: number; useJapaneseBadge?: boolean };
+				toc?: {
+					depth?: number;
+					badgeStyle?: unknown;
+					useJapaneseBadge?: boolean;
+				};
 			};
 		}
 	).siteConfig;
+	const badgeStyle = normalizeTOCBadgeStyle(
+		siteConfig?.toc?.badgeStyle,
+		siteConfig?.toc?.useJapaneseBadge,
+	);
 	return {
 		depth: siteConfig?.toc?.depth ?? 3,
-		useJapaneseBadge: siteConfig?.toc?.useJapaneseBadge ?? false,
+		badgeStyle,
+		useJapaneseBadge: badgeStyle === "katakana",
 	};
 }
 

--- a/src/components/features/toc/index.ts
+++ b/src/components/features/toc/index.ts
@@ -73,9 +73,13 @@ export {
 // Calculator utilities
 export {
 	getKatakanaBadge,
+	getTOCBadge,
 	JAPANESE_KATAKANA,
 	KATAKANA_COUNT,
+	normalizeTOCBadgeStyle,
+	ROMAN_NUMERALS,
 } from "./utils/japanese-katakana";
+export type { TOCBadgeStyle } from "./utils/japanese-katakana";
 export {
 	getMinLevel as calcMinLevel,
 	generateTOCItems as calcTOCItems,

--- a/src/components/features/toc/types.ts
+++ b/src/components/features/toc/types.ts
@@ -14,7 +14,7 @@ export interface TOCItem {
 	level: number;
 	/** 相对深度（0 = 顶级） */
 	depth: number;
-	/** 徽章文本（数字或日语字符） */
+	/** 徽章文本（数字、日语片假名或罗马数字） */
 	badge?: string;
 }
 
@@ -28,7 +28,9 @@ export interface TOCConfig {
 	mode: "float" | "sidebar";
 	/** 标题深度（1-6） */
 	depth: number;
-	/** 是否使用日语徽章 */
+	/** 徽章样式 */
+	badgeStyle: "number" | "katakana" | "roman";
+	/** @deprecated 使用 badgeStyle 代替 */
 	useJapaneseBadge: boolean;
 }
 

--- a/src/components/features/toc/types/toc.ts
+++ b/src/components/features/toc/types/toc.ts
@@ -11,7 +11,7 @@ export interface TOCItem {
 	level: number;
 	/** 相对深度（0 = 顶级） */
 	depth: number;
-	/** 徽章文本（数字或日语字符） */
+	/** 徽章文本（数字、日语片假名或罗马数字） */
 	badge?: string;
 }
 
@@ -22,7 +22,9 @@ export interface TOCConfig {
 	mode: "float" | "sidebar";
 	/** 标题深度（1-6） */
 	depth: number;
-	/** 是否使用日语徽章 */
+	/** 徽章样式 */
+	badgeStyle: "number" | "katakana" | "roman";
+	/** @deprecated 使用 badgeStyle 代替 */
 	useJapaneseBadge: boolean;
 }
 

--- a/src/components/features/toc/utils/japanese-katakana.ts
+++ b/src/components/features/toc/utils/japanese-katakana.ts
@@ -1,10 +1,10 @@
 /**
- * 日语片假名字符集
- * 用于 TOC 徽章显示
+ * TOC 徽章字符集
+ * 用于 TOC 徽章显示，支持多种计数方式
  */
 
 /**
- * 完整的日语片假名字符集（46 个字符）
+ * 日语片假名字符集（46 个字符）
  * 按五十音图顺序排列
  */
 export const JAPANESE_KATAKANA = [
@@ -66,19 +66,75 @@ export const JAPANESE_KATAKANA = [
 	"ン",
 ] as const;
 
+/**
+ * 罗马数字字符集（12 个）
+ * 固定宽度徽章只适合单个罗马数字字符，超过 12 后回退为数字。
+ */
+export const ROMAN_NUMERALS = [
+	"Ⅰ",
+	"Ⅱ",
+	"Ⅲ",
+	"Ⅳ",
+	"Ⅴ",
+	"Ⅵ",
+	"Ⅶ",
+	"Ⅷ",
+	"Ⅸ",
+	"Ⅹ",
+	"Ⅺ",
+	"Ⅻ",
+] as const;
+
+export type TOCBadgeStyle = "number" | "katakana" | "roman";
+
 export type JapaneseKatakanaChar = (typeof JAPANESE_KATAKANA)[number];
 
 /**
- * 获取 TOC 徽章文本
+ * 规范化运行时传入的 TOC 徽章样式。
+ * @param value - 可能来自全局配置或 data-* 属性的运行时值
+ * @param useJapaneseBadge - 旧版布尔配置的兼容回退
+ * @returns 有效的徽章样式
+ */
+export function normalizeTOCBadgeStyle(
+	value: unknown,
+	useJapaneseBadge?: boolean,
+): TOCBadgeStyle {
+	if (value === "number" || value === "katakana" || value === "roman") {
+		return value;
+	}
+	return useJapaneseBadge ? "katakana" : "number";
+}
+
+/**
+ * 根据 badgeStyle 获取 TOC 徽章文本
  * @param index - 索引（从 0 开始）
- * @param useJapanese - 是否使用日语字符
+ * @param badgeStyle - 徽章样式："number" | "katakana" | "roman"
  * @returns 徽章文本
  */
-export function getKatakanaBadge(index: number, useJapanese: boolean): string {
-	if (useJapanese && index < JAPANESE_KATAKANA.length) {
-		return JAPANESE_KATAKANA[index];
+export function getTOCBadge(index: number, badgeStyle: TOCBadgeStyle): string {
+	switch (badgeStyle) {
+		case "katakana":
+			if (index < JAPANESE_KATAKANA.length) {
+				return JAPANESE_KATAKANA[index];
+			}
+			return (index + 1).toString();
+		case "roman":
+			if (index < ROMAN_NUMERALS.length) {
+				return ROMAN_NUMERALS[index];
+			}
+			return (index + 1).toString();
+		case "number":
+		default:
+			return (index + 1).toString();
 	}
-	return (index + 1).toString();
+}
+
+/**
+ * 兼容旧接口：根据 useJapanese 布尔值获取徽章
+ * @deprecated 请使用 getTOCBadge(index, badgeStyle) 代替
+ */
+export function getKatakanaBadge(index: number, useJapanese: boolean): string {
+	return getTOCBadge(index, useJapanese ? "katakana" : "number");
 }
 
 /**

--- a/src/components/features/toc/utils/toc-calculator.ts
+++ b/src/components/features/toc/utils/toc-calculator.ts
@@ -4,7 +4,7 @@
  */
 
 import type { HeadingData, TOCItem } from "../types/toc";
-import { JAPANESE_KATAKANA } from "./japanese-katakana";
+import { getTOCBadge, type TOCBadgeStyle } from "./japanese-katakana";
 
 /**
  * 计算最小标题级别
@@ -23,16 +23,13 @@ export function getBadgeText(
 	index: number,
 	level: number,
 	minLevel: number,
-	useJapaneseBadge: boolean,
+	badgeStyle: TOCBadgeStyle,
 ): string {
 	if (level !== minLevel) {
 		return "";
 	}
 
-	if (useJapaneseBadge && index < JAPANESE_KATAKANA.length) {
-		return JAPANESE_KATAKANA[index];
-	}
-	return (index + 1).toString();
+	return getTOCBadge(index, badgeStyle);
 }
 
 /**
@@ -41,7 +38,7 @@ export function getBadgeText(
 export function generateTOCItems(
 	headings: HeadingData[],
 	depth: number,
-	useJapaneseBadge: boolean,
+	badgeStyle: TOCBadgeStyle,
 ): TOCItem[] {
 	if (headings.length === 0) {
 		return [];
@@ -58,7 +55,7 @@ export function generateTOCItems(
 				h1Count,
 				h.level,
 				minLevel,
-				useJapaneseBadge,
+				badgeStyle,
 			);
 
 			if (h.level === minLevel) {

--- a/src/components/features/toc/utils/toc-utils.ts
+++ b/src/components/features/toc/utils/toc-utils.ts
@@ -3,7 +3,7 @@
  */
 
 import type { HeadingData, TOCConfig, TOCItem } from "../types/toc";
-import { getKatakanaBadge } from "./japanese-katakana";
+import { getTOCBadge, normalizeTOCBadgeStyle } from "./japanese-katakana";
 
 /**
  * 从 DOM 中提取标题数据
@@ -66,7 +66,7 @@ export function generateTOCItems(
 			let badge: string | undefined;
 
 			if (h.level === minLevel) {
-				badge = getKatakanaBadge(h1Count, config.useJapaneseBadge);
+				badge = getTOCBadge(h1Count, config.badgeStyle);
 				h1Count++;
 			}
 
@@ -129,11 +129,16 @@ export function createHeadingObserver(
  */
 export function getTOCConfig(): TOCConfig {
 	const siteConfig = window.siteConfig || {};
+	const badgeStyle = normalizeTOCBadgeStyle(
+		siteConfig.toc?.badgeStyle,
+		siteConfig.toc?.useJapaneseBadge,
+	);
 	return {
 		enable: siteConfig.toc?.enable ?? true,
 		mode: siteConfig.toc?.mode ?? "sidebar",
 		depth: siteConfig.toc?.depth ?? 3,
-		useJapaneseBadge: siteConfig.toc?.useJapaneseBadge ?? false,
+		badgeStyle,
+		useJapaneseBadge: badgeStyle === "katakana",
 	};
 }
 

--- a/src/components/misc/ConfigCarrier.astro
+++ b/src/components/misc/ConfigCarrier.astro
@@ -1,5 +1,11 @@
 ---
 import { expressiveCodeConfig, siteConfig } from "@/config";
+import { normalizeTOCBadgeStyle } from "@/components/features/toc/utils/japanese-katakana";
+
+const tocBadgeStyle = normalizeTOCBadgeStyle(
+	siteConfig.toc.badgeStyle,
+	siteConfig.toc.useJapaneseBadge,
+);
 ---
 
 <!-- 全局配置载体 -->
@@ -17,7 +23,7 @@ import { expressiveCodeConfig, siteConfig } from "@/config";
 	define:vars={{
 		tocEnable: siteConfig.toc.enable,
 		tocDepth: siteConfig.toc.depth,
-		tocUseJapaneseBadge: siteConfig.toc.useJapaneseBadge,
+		tocBadgeStyle,
 	}}
 >
 	// 将 TOC 配置传递到前端
@@ -25,9 +31,8 @@ import { expressiveCodeConfig, siteConfig } from "@/config";
 	window.siteConfig.toc = {
 		enable: tocEnable,
 		depth: tocDepth,
-		useJapaneseBadge: tocUseJapaneseBadge,
+		badgeStyle: tocBadgeStyle,
+		// 兼容旧接口
+		useJapaneseBadge: tocBadgeStyle === "katakana",
 	};
-
-	// 添加调试信息
-	console.log("TOC Config:", window.siteConfig.toc);
 </script>

--- a/src/components/widgets/card-toc/CardTOC.astro
+++ b/src/components/widgets/card-toc/CardTOC.astro
@@ -9,6 +9,7 @@ import "@/styles/toc.css";
 
 import type { MarkdownHeading } from "astro";
 import { siteConfig } from "@/config";
+import { normalizeTOCBadgeStyle } from "@/components/features/toc/utils/japanese-katakana";
 
 import I18nKey from "../../../i18n/i18nKey";
 import { i18n } from "../../../i18n/translation";
@@ -21,7 +22,10 @@ interface Props {
 }
 
 const { class: className, style } = Astro.props;
-const useJapaneseBadge = siteConfig.toc.useJapaneseBadge;
+const badgeStyle = normalizeTOCBadgeStyle(
+	siteConfig.toc.badgeStyle,
+	siteConfig.toc.useJapaneseBadge,
+);
 ---
 
 <WidgetLayout
@@ -30,7 +34,7 @@ const useJapaneseBadge = siteConfig.toc.useJapaneseBadge;
 	class={"group " + (className || "")}
 	style={style}
 >
-	<div data-card-toc-root data-japanese-badge={String(useJapaneseBadge)}>
+	<div data-card-toc-root data-badge-style={badgeStyle}>
 		<div class="toc-scroll-container">
 			<div class="toc-content" data-card-toc-content></div>
 		</div>
@@ -53,6 +57,7 @@ const useJapaneseBadge = siteConfig.toc.useJapaneseBadge;
 </style>
 
 <script>
+	import { normalizeTOCBadgeStyle } from "@/components/features/toc/utils/japanese-katakana";
 	import { TOCManager } from "@/utils/tocManager";
 
 	const cardTocManagers = new WeakMap();
@@ -80,12 +85,12 @@ const useJapaneseBadge = siteConfig.toc.useJapaneseBadge;
 				existingManager.cleanup();
 			}
 
-			const useJapaneseBadge = root.dataset.japaneseBadge === "true";
+			const badgeStyle = normalizeTOCBadgeStyle(root.dataset.badgeStyle);
 
 			const manager = new TOCManager({
 				contentElement: tocContent,
 				maxLevel: 3,
-				useJapaneseBadge,
+				badgeStyle,
 				scrollOffset: 80,
 			});
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-﻿import type {
+import type {
 	AnnouncementConfig,
 	CommentConfig,
 	ExpressiveCodeConfig,
@@ -197,7 +197,7 @@ export const siteConfig: SiteConfig = {
 		desktopSidebar: true, // 电脑端右侧边栏 TOC
 		floating: true, // 悬浮 TOC 按钮
 		depth: 2, // 目录深度，1-6，1 表示只显示 h1 标题，2 表示显示 h1 和 h2 标题，依此类推
-		useJapaneseBadge: true, // 使用日语假名标记（あいうえお...）代替数字，开启后会将 1、2、3... 改为 あ、い、う...
+		badgeStyle: "katakana", // TOC 徽章样式："number" 使用数字 1、2、3...，"katakana" 使用日语片假名 ア、イ、ウ...，"roman" 使用罗马数字 Ⅰ、Ⅱ、Ⅲ...
 	},
 	showCoverInContent: true, // 在文章内容页显示文章封面
 	generateOgImages: false, // 启用生成OpenGraph图片功能,注意开启后要渲染很长时间，不建议本地调试的时候开启

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -27,6 +27,7 @@ declare global {
 		enable?: boolean;
 		mode?: "float" | "sidebar";
 		depth?: number;
+		badgeStyle?: "number" | "katakana" | "roman";
 		useJapaneseBadge?: boolean;
 	}
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -186,7 +186,8 @@ export interface SiteConfig {
 		desktopSidebar: boolean; // 电脑端右侧边栏 TOC
 		floating: boolean; // 悬浮 TOC 按钮
 		depth: 1 | 2 | 3;
-		useJapaneseBadge?: boolean; // 使用日语假名标记（あいうえお...）代替数字
+		badgeStyle?: "number" | "katakana" | "roman"; // TOC 徽章样式："number" 数字, "katakana" 日语片假名, "roman" 罗马数字
+		useJapaneseBadge?: boolean; // @deprecated 已废弃，请使用 badgeStyle 代替
 	};
 	showCoverInContent: boolean; // 控制文章封面在文章内容页显示的开关
 	generateOgImages: boolean;

--- a/src/utils/tocManager.ts
+++ b/src/utils/tocManager.ts
@@ -4,7 +4,11 @@
  * 基于 Firefly 项目的 TOCManager 实现
  */
 
-import { JAPANESE_KATAKANA } from "../components/features/toc/utils/japanese-katakana";
+import {
+	getTOCBadge,
+	normalizeTOCBadgeStyle,
+	type TOCBadgeStyle,
+} from "../components/features/toc/utils/japanese-katakana";
 import I18nKey from "../i18n/i18nKey";
 import { i18n } from "../i18n/translation";
 
@@ -13,6 +17,8 @@ export interface TOCConfig {
 	contentElement?: HTMLElement;
 	maxLevel?: number;
 	scrollOffset?: number;
+	badgeStyle?: TOCBadgeStyle;
+	/** @deprecated 使用 badgeStyle 代替 */
 	useJapaneseBadge?: boolean;
 }
 
@@ -25,14 +31,18 @@ export class TOCManager {
 	private contentId: string | null;
 	private contentElement: HTMLElement | null;
 	private scrollOffset: number;
-	private useJapaneseBadge: boolean;
+	private badgeStyle: TOCBadgeStyle;
 
 	constructor(config: TOCConfig) {
 		this.contentId = config.contentId ?? null;
 		this.contentElement = config.contentElement ?? null;
 		this.maxLevel = config.maxLevel || 3;
 		this.scrollOffset = config.scrollOffset || 80;
-		this.useJapaneseBadge = config.useJapaneseBadge ?? false;
+		const legacyConfig = config as { useJapaneseBadge?: boolean };
+		this.badgeStyle = normalizeTOCBadgeStyle(
+			config.badgeStyle,
+			legacyConfig.useJapaneseBadge,
+		);
 	}
 
 	/**
@@ -114,13 +124,7 @@ export class TOCManager {
 
 	private generateBadgeContent(depth: number, heading1Count: number): string {
 		if (depth === this.minDepth) {
-			if (
-				this.useJapaneseBadge &&
-				heading1Count - 1 < JAPANESE_KATAKANA.length
-			) {
-				return JAPANESE_KATAKANA[heading1Count - 1];
-			}
-			return heading1Count.toString();
+			return getTOCBadge(heading1Count - 1, this.badgeStyle);
 		}
 		if (depth === this.minDepth + 1) {
 			return '<span class="toc-badge-dot"></span>';


### PR DESCRIPTION
## Summary
- add `badgeStyle` support for TOC badges while keeping `useJapaneseBadge` as a deprecated compatibility option
- centralize badge generation through `getTOCBadge()` and runtime validation through `normalizeTOCBadgeStyle()`
- limit roman badge output to single-character numerals (`Ⅰ`-`Ⅻ`) so fixed-width badge layouts do not overflow

## Validation
- `pnpm exec astro check`
