### PR TITLE
fix: show Fancybox rotation controls

### DIFF
--- a/src/scripts/core/swup-config.ts
+++ b/src/scripts/core/swup-config.ts
@@ -3,6 +3,8 @@
  * 提供页面过渡动画的配置常量和类型定义
  */
 
+import type { FancyboxOptions } from "@fancyapps/ui";
+
 // Banner 高度常量
 export const BANNER_HEIGHT = 35;
 export const BANNER_HEIGHT_EXTEND = 30;
@@ -165,50 +167,34 @@ export interface CarouselConfig {
 }
 
 // Fancybox 配置类型
-export interface FancyboxConfig {
-	Thumbs: {
-		autoStart: boolean;
-		showOnStart: string;
-	};
-	Toolbar: {
-		display: {
-			left: string[];
-			middle: string[];
-			right: string[];
-		};
-	};
-	animated: boolean;
-	dragToClose: boolean;
-	keyboard: Record<string, string>;
-	fitToView: boolean;
-	preload: number;
-	infinite: boolean;
-	Panzoom: {
-		maxScale: number;
-		minScale: number;
-	};
-	caption: boolean;
-}
+export type FancyboxConfig = Partial<FancyboxOptions>;
 
 // 默认 Fancybox 配置
 export const getDefaultFancyboxConfig = (): FancyboxConfig => ({
-	Thumbs: { autoStart: true, showOnStart: "yes" },
-	Toolbar: {
-		display: {
-			left: ["infobar"],
-			middle: [
-				"zoomIn",
-				"zoomOut",
-				"toggle1to1",
-				"rotateCCW",
-				"rotateCW",
-				"flipX",
-				"flipY",
-			],
-			right: ["slideshow", "thumbs", "close"],
+	Carousel: {
+		infinite: true,
+		Lazyload: { preload: 3 },
+		Thumbs: { showOnStart: true },
+		Toolbar: {
+			display: {
+				left: ["counter"],
+				middle: [
+					"zoomIn",
+					"zoomOut",
+					"toggle1to1",
+					"rotateCCW",
+					"rotateCW",
+					"flipX",
+					"flipY",
+					"reset",
+				],
+				right: ["autoplay", "fullscreen", "thumbs", "close"],
+			},
+		},
+		Zoomable: {
+			Panzoom: { maxScale: 3, minScale: 1 },
 		},
 	},
-	animated: true,
 	dragToClose: true,
 	keyboard: {
 		Escape: "close",
@@ -221,11 +207,6 @@ export const getDefaultFancyboxConfig = (): FancyboxConfig => ({
 		ArrowRight: "next",
 		ArrowLeft: "prev",
 	},
-	fitToView: true,
-	preload: 3,
-	infinite: true,
-	Panzoom: { maxScale: 3, minScale: 1 },
-	caption: false,
 });
 
 // Fancybox 选择器

--- a/src/scripts/handlers/fancybox-handler.ts
+++ b/src/scripts/handlers/fancybox-handler.ts
@@ -5,6 +5,7 @@
 
 import {
 	FANCYBOX_SELECTORS,
+	type FancyboxConfig,
 	getDefaultFancyboxConfig,
 } from "../core/swup-config";
 
@@ -76,14 +77,10 @@ export class FancyboxHandler {
 		const commonConfig = getDefaultFancyboxConfig();
 
 		// 绑定相册/文章图片
-		this.Fancybox.bind(FANCYBOX_SELECTORS.albumImages, {
-			...commonConfig,
-			groupAll: true,
-			Carousel: {
-				transition: "slide",
-				preload: 2,
-			},
-		});
+		this.Fancybox.bind(
+			FANCYBOX_SELECTORS.albumImages,
+			this.createAlbumImagesConfig(commonConfig),
+		);
 		this.boundSelectors.push(FANCYBOX_SELECTORS.albumImages);
 
 		// 绑定相册链接
@@ -98,6 +95,28 @@ export class FancyboxHandler {
 		// 绑定单独的 fancybox 图片
 		this.Fancybox.bind(FANCYBOX_SELECTORS.singleFancybox, commonConfig);
 		this.boundSelectors.push(FANCYBOX_SELECTORS.singleFancybox);
+	}
+
+	/**
+	 * 创建相册/文章图片配置
+	 * 保留默认 Carousel 插件配置，避免覆盖旋转工具栏
+	 */
+	private createAlbumImagesConfig(commonConfig: FancyboxConfig): FancyboxConfig {
+		const carouselConfig = commonConfig.Carousel ?? {};
+		const lazyloadConfig = carouselConfig.Lazyload;
+
+		return {
+			...commonConfig,
+			groupAll: true,
+			Carousel: {
+				...carouselConfig,
+				transition: "slide",
+				Lazyload: {
+					...(typeof lazyloadConfig === "object" ? lazyloadConfig : {}),
+					preload: 2,
+				},
+			},
+		};
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Move Fancybox toolbar, thumbs, lazyload, and zoom options under `Carousel` for `@fancyapps/ui` v6
- Use Fancybox v6 toolbar item names and include rotate, flip, and reset Panzoom controls
- Preserve the default `Carousel` plugin config when binding article/gallery images

## Tests
- `pnpm type-check`

Fixes #474