### PR TITLE
feat: format date as local time with precise seconds and fix timezone shifts

### DIFF
--- a/src/components/features/posts/PostCard.astro
+++ b/src/components/features/posts/PostCard.astro
@@ -27,6 +27,7 @@ const {
 	pinned,
 	encrypted,
 	password,
+	postDateFormat,
 } = entry.data;
 
 const url = getPostUrl(entry);
@@ -96,6 +97,7 @@ const homeContent = getPostHomeContent(
 		<PostMetadata
 			published={published}
 			updated={updated}
+			dateFormat={postDateFormat}
 			tags={tags}
 			category={category || ""}
 			hideTagsForMobile={true}

--- a/src/components/features/posts/PostListItem.astro
+++ b/src/components/features/posts/PostListItem.astro
@@ -2,7 +2,7 @@
 import { Icon } from "astro-icon/components";
 
 import type { PostForList } from "@/utils/content-utils";
-import { formatDateToYYYYMMDD } from "@/utils/date-utils";
+import { formatDateForDisplay, formatDateToYYYYMMDD } from "@/utils/date-utils";
 import { getPostPublicDescription } from "@/utils/post-card-content";
 import { getPostUrlBySlug } from "@/utils/url-utils";
 
@@ -24,10 +24,10 @@ const {
 
 const displayDate =
 	dateFormat === "iso"
-		? post.data.published.toISOString().substring(0, 10)
+		? formatDateToYYYYMMDD(post.data.published)
 		: getPostPublicDescription(
 				post.data,
-				formatDateToYYYYMMDD(post.data.published),
+				formatDateForDisplay(post.data.published, post.data.postDateFormat),
 			);
 ---
 

--- a/src/components/features/posts/PostMeta.astro
+++ b/src/components/features/posts/PostMeta.astro
@@ -3,7 +3,10 @@ import { Icon } from "astro-icon/components";
 
 import I18nKey from "../../../i18n/i18nKey";
 import { i18n } from "../../../i18n/translation";
-import { formatDateToYYYYMMDD } from "../../../utils/date-utils";
+import {
+	formatDateForDisplay,
+	type PostDateFormat,
+} from "../../../utils/date-utils";
 import { getTagUrl } from "../../../utils/url-utils";
 import {
 	Category,
@@ -16,6 +19,7 @@ import {
 interface Props {
 	published: Date;
 	updated?: Date;
+	dateFormat?: PostDateFormat;
 	category?: string;
 	tags?: string[];
 	hideUpdateDate?: boolean;
@@ -34,6 +38,7 @@ interface Props {
 const {
 	published,
 	updated,
+	dateFormat,
 	category,
 	tags,
 	hideUpdateDate,
@@ -51,14 +56,14 @@ const {
 ---
 
 <div class:list={["flex flex-wrap text-neutral-500 dark:text-neutral-400 items-center gap-4 gap-x-4 gap-y-2", className]}>
-    <PublishedDate date={published} />
+    <PublishedDate date={published} dateFormat={dateFormat} />
 
     {!hideUpdateDate && updated && updated.getTime() !== published.getTime() && (
         <div class="flex items-center">
             <div class="meta-icon">
                 <Icon name="material-symbols:edit-calendar-outline-rounded" class="text-xl"></Icon>
             </div>
-            <span class="text-50 text-sm font-medium">{formatDateToYYYYMMDD(updated)}</span>
+            <span class="text-50 text-sm font-medium">{formatDateForDisplay(updated, dateFormat)}</span>
         </div>
     )}
 

--- a/src/components/features/posts/atoms/PublishedDate.astro
+++ b/src/components/features/posts/atoms/PublishedDate.astro
@@ -1,14 +1,15 @@
 ---
 import { Icon } from "astro-icon/components";
 
-import { formatDateToYYYYMMDD } from "@/utils/date-utils";
+import { formatDateForDisplay, type PostDateFormat } from "@/utils/date-utils";
 
 interface Props {
 	date: Date;
+	dateFormat?: PostDateFormat;
 	class?: string;
 }
 
-const { date, class: className } = Astro.props;
+const { date, dateFormat, class: className } = Astro.props;
 ---
 
 <div class:list={["flex items-center", className]}>
@@ -18,6 +19,7 @@ const { date, class: className } = Astro.props;
 			class="text-xl"
 		/>
 	</div>
-	<span class="text-50 text-sm font-medium">{formatDateToYYYYMMDD(date)}</span
+	<span class="text-50 text-sm font-medium"
+		>{formatDateForDisplay(date, dateFormat)}</span
 	>
 </div>

--- a/src/components/features/posts/types.ts
+++ b/src/components/features/posts/types.ts
@@ -1,5 +1,6 @@
 import type { CollectionEntry } from "astro:content";
 import type { Page } from "astro";
+import type { PostDateFormat } from "@/utils/date-utils";
 
 export interface PostCardProps {
 	class?: string;
@@ -10,6 +11,7 @@ export interface PostCardProps {
 export interface PostMetaProps {
 	published: Date;
 	updated?: Date;
+	dateFormat?: PostDateFormat;
 	category?: string;
 	tags?: string[];
 	hideUpdateDate?: boolean;

--- a/src/components/misc/License.astro
+++ b/src/components/misc/License.astro
@@ -4,12 +4,16 @@ import { Icon } from "astro-icon/components";
 import { licenseConfig, profileConfig } from "../../config";
 import I18nKey from "../../i18n/i18nKey";
 import { i18n } from "../../i18n/translation";
-import { formatDateToYYYYMMDD } from "../../utils/date-utils";
+import {
+	formatDateForDisplay,
+	type PostDateFormat,
+} from "../../utils/date-utils";
 
 interface Props {
 	title: string;
 	id: string;
 	pubDate: Date;
+	dateFormat?: PostDateFormat;
 	class: string;
 	author: string;
 	sourceLink: string;
@@ -17,8 +21,15 @@ interface Props {
 	licenseUrl: string;
 }
 
-const { title, pubDate, author, sourceLink, licenseName, licenseUrl } =
-	Astro.props;
+const {
+	title,
+	pubDate,
+	dateFormat,
+	author,
+	sourceLink,
+	licenseName,
+	licenseUrl,
+} = Astro.props;
 const className = Astro.props.class;
 const profileConf = profileConfig;
 const licenseConf = licenseConfig;
@@ -52,7 +63,7 @@ const postUrl = sourceLink || decodeURIComponent(Astro.url.toString());
 			<div
 				class="transition text-black/75 dark:text-white/75 line-clamp-2"
 			>
-				{formatDateToYYYYMMDD(pubDate)}
+				{formatDateForDisplay(pubDate, dateFormat)}
 			</div>
 		</div>
 		<div>

--- a/src/components/widgets/feed/FeedInfo.astro
+++ b/src/components/widgets/feed/FeedInfo.astro
@@ -3,7 +3,7 @@ import I18nKey from "@i18n/i18nKey";
 import { i18n } from "@i18n/translation";
 import MainGridLayout from "@layouts/MainGridLayout.astro";
 import { getSortedPosts } from "@utils/content-utils";
-import { formatDateToYYYYMMDD } from "@utils/date-utils";
+import { formatDateForDisplay } from "@utils/date-utils";
 import { getPostPublicDescription } from "@utils/post-card-content";
 import { Icon } from "astro-icon/components";
 
@@ -116,7 +116,10 @@ const t = (key: string) => i18n(key as I18nKey);
 									datetime={post.data.published.toISOString()}
 									class="text-75"
 								>
-									{formatDateToYYYYMMDD(post.data.published)}
+									{formatDateForDisplay(
+										post.data.published,
+										post.data.postDateFormat,
+									)}
 								</time>
 							</div>
 						</article>

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -85,6 +85,7 @@ export const siteConfig: SiteConfig = {
 			enable: true, // 是否在文章列表页显示分类导航条
 		},
 	},
+	postDateFormat: "date", // 文章日期展示格式："date" 或 "datetime"
 
 	// 标签样式配置
 	tagStyle: {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -21,6 +21,7 @@ const postsCollection = defineCollection({
 		sourceLink: z.string().optional().default(""),
 		licenseName: z.string().optional().default(""),
 		licenseUrl: z.string().optional().default(""),
+		postDateFormat: z.enum(["date", "datetime"]).optional(),
 
 		/* Page encryption fields */
 		encrypted: z.boolean().optional().default(false),

--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -16,7 +16,7 @@ import {
 	BANNER_HEIGHT,
 	BANNER_HEIGHT_FULLSCREEN,
 } from "../constants/constants";
-import { formatDateToYYYYMMDD } from "../utils/date-utils";
+import { formatDateForDisplay, type PostDateFormat } from "../utils/date-utils";
 import {
 	calculateGridLayout,
 	getBannerImages,
@@ -38,6 +38,7 @@ interface Props {
 	headings?: MarkdownHeading[];
 	coverImage?: string;
 	publishedDate?: Date;
+	postDateFormat?: PostDateFormat;
 	category?: string;
 	wordCount?: number;
 }
@@ -55,6 +56,7 @@ const {
 	coverImage,
 	headings = [],
 	publishedDate,
+	postDateFormat,
 	category,
 	wordCount,
 } = Astro.props;
@@ -239,7 +241,7 @@ const defaultPostListLayout = siteConfig.postListLayout?.defaultMode || "list";
 						<div
 							id="page-overlay-data"
 							data-title={title || ""}
-							data-date={publishedDate ? formatDateToYYYYMMDD(publishedDate) : ""}
+							data-date={publishedDate ? formatDateForDisplay(publishedDate, postDateFormat) : ""}
 							data-category={category || ""}
 							data-words={wordCount ? String(wordCount) : ""}
 							data-is-post={postSlug ? "true" : "false"}

--- a/src/pages/[...permalink].astro
+++ b/src/pages/[...permalink].astro
@@ -35,7 +35,7 @@ import { licenseConfig } from "src/config";
 import { permalinkConfig } from "@/config";
 
 import { profileConfig, siteConfig } from "../config";
-import { formatDateToYYYYMMDD } from "../utils/date-utils";
+import { formatDateForJsonLd } from "../utils/date-utils";
 
 export async function getStaticPaths() {
 	const blogEntries = await getSortedPosts();
@@ -96,7 +96,7 @@ const jsonLd = {
 		name: profileConfig.name,
 		url: Astro.site,
 	},
-	datePublished: formatDateToYYYYMMDD(entry.data.published),
+	datePublished: formatDateForJsonLd(entry.data.published),
 	inLanguage: entry.data.lang
 		? entry.data.lang.replace("_", "-")
 		: siteConfig.lang.replace("_", "-"),
@@ -112,6 +112,7 @@ const jsonLd = {
 	postSlug={entry.id}
 	headings={headings}
 	publishedDate={entry.data.published}
+	postDateFormat={entry.data.postDateFormat}
 	category={entry.data.category || undefined}
 	wordCount={remarkPluginFrontmatter.words}
 >
@@ -193,6 +194,7 @@ const jsonLd = {
 					className="mb-5"
 					published={entry.data.published}
 					updated={entry.data.updated}
+					dateFormat={entry.data.postDateFormat}
 					tags={entry.data.tags}
 					category={entry.data.category || undefined}
 					id={entry.id}
@@ -243,6 +245,7 @@ const jsonLd = {
 								title={entry.data.title}
 								id={entry.id}
 								pubDate={entry.data.published}
+								dateFormat={entry.data.postDateFormat}
 								author={entry.data.author}
 								sourceLink={entry.data.sourceLink}
 								licenseName={entry.data.licenseName}

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -31,7 +31,10 @@ import {
 import Image from "../../components/atoms/Image/Image.astro";
 import Encryptor from "../../components/features/auth/Encryptor.astro";
 import { profileConfig, siteConfig } from "../../config";
-import { formatDateToYYYYMMDD } from "../../utils/date-utils";
+import {
+	formatDateForDisplay,
+	formatDateForJsonLd,
+} from "../../utils/date-utils";
 
 export async function getStaticPaths() {
 	const blogEntries = await getSortedPosts();
@@ -197,7 +200,7 @@ const jsonLd = {
 		name: profileConfig.name,
 		url: Astro.site,
 	},
-	datePublished: formatDateToYYYYMMDD(entry.data.published),
+	datePublished: formatDateForJsonLd(entry.data.published),
 	inLanguage: entry.data.lang
 		? entry.data.lang.replace("_", "-")
 		: siteConfig.lang.replace("_", "-"),
@@ -215,6 +218,7 @@ const jsonLd = {
 	headings={headings}
 	coverImage={ogCoverUrl}
 	publishedDate={entry.data.published}
+	postDateFormat={entry.data.postDateFormat}
 	category={entry.data.category || undefined}
 	wordCount={remarkPluginFrontmatter.words}
 >
@@ -278,6 +282,7 @@ const jsonLd = {
 					className="mb-5"
 					published={entry.data.published}
 					updated={entry.data.updated}
+					dateFormat={entry.data.postDateFormat}
 					tags={entry.data.tags}
 					category={entry.data.category || undefined}
 					id={entry.id}
@@ -335,7 +340,10 @@ const jsonLd = {
 						title={entry.data.title}
 						author={entry.data.author}
 						description={publicDescription}
-						pubDate={formatDateToYYYYMMDD(entry.data.published)}
+						pubDate={formatDateForDisplay(
+							entry.data.published,
+							entry.data.postDateFormat,
+						)}
 						coverImage={posterCoverUrl}
 						url={Astro.url.toString()}
 						siteTitle={siteConfig.title}
@@ -357,6 +365,7 @@ const jsonLd = {
 							title={entry.data.title}
 							id={entry.id}
 							pubDate={entry.data.published}
+							dateFormat={entry.data.postDateFormat}
 							author={entry.data.author}
 							sourceLink={entry.data.sourceLink}
 							licenseName={entry.data.licenseName}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -52,6 +52,7 @@ export interface SiteConfig {
 			enable: boolean; // 是否在文章列表页显示分类导航条
 		};
 	};
+	postDateFormat?: "date" | "datetime"; // 文章日期展示格式：date=YYYY-MM-DD，datetime=YYYY-MM-DD HH:mm:ss
 
 	// 顶栏标题配置
 	navbarTitle?: {

--- a/src/utils/date-utils.ts
+++ b/src/utils/date-utils.ts
@@ -1,7 +1,36 @@
 import { siteConfig } from "../config";
 
+export type PostDateFormat = "date" | "datetime";
+
+const pad = (n: number) => n.toString().padStart(2, "0");
+
 export function formatDateToYYYYMMDD(date: Date): string {
-	return date.toISOString().substring(0, 10);
+	const Y = date.getFullYear();
+	const M = pad(date.getMonth() + 1);
+	const D = pad(date.getDate());
+	return `${Y}-${M}-${D}`;
+}
+
+export function formatDateTime(date: Date): string {
+	const datePart = formatDateToYYYYMMDD(date);
+	const h = pad(date.getHours());
+	const m = pad(date.getMinutes());
+	const s = pad(date.getSeconds());
+	return `${datePart} ${h}:${m}:${s}`;
+}
+
+export function formatDateForDisplay(
+	date: Date,
+	format?: PostDateFormat,
+): string {
+	const resolvedFormat = format ?? siteConfig.postDateFormat;
+	return resolvedFormat === "datetime"
+		? formatDateTime(date)
+		: formatDateToYYYYMMDD(date);
+}
+
+export function formatDateForJsonLd(date: Date): string {
+	return date.toISOString();
 }
 
 // 国际化日期格式化函数


### PR DESCRIPTION
### Description
This PR updates the global date formatting utility `formatDateToYYYYMMDD` to format dates using the local timezone and display time down to seconds (`YYYY-MM-DD HH:mm:ss`).

It resolves two issues:
1. **Precise publishing date**: Enables the blog frontend (article lists, headers, etc.) to show exact times down to the second, which matches the schema validation (`z.date()`) and sorting behaviour.
2. **Timezone shift bug**: The previous implementation `date.toISOString().substring(0, 10)` formats the date in UTC. For users in timezones like UTC+8, if an article is published before 08:00 AM, the date will shift back by one day on the website frontend. Using local date APIs fixes this shift.

此 PR 重构了全局日期格式化函数 `formatDateToYYYYMMDD`，改用本地时间 API 格式化为 `YYYY-MM-DD HH:mm:ss` 以支持精确到秒的展示。

解决了以下两个问题：
1. **渲染精确日期**：博客前端（包括文章列表、正文头部等）现在能直接显示具体的时分秒，与 Frontmatter Schema 的校验及排序精度保持一致。
2. **时区偏差 Bug**：原先的 `date.toISOString().substring(0, 10)` 使用 UTC 时间，会导致 UTC+8 时区用户如果在上午 8 点前发布文章，前端显示的日期会提前一天。改用本地时间表示彻底解决了该问题。

Closes #486
