### PR TITLE
fix: handle non-ASCII OG endpoint paths

### DIFF
--- a/src/pages/og/[...slug].ts
+++ b/src/pages/og/[...slug].ts
@@ -30,8 +30,9 @@ export const getStaticPaths: GetStaticPaths = async () => {
 	const publishedPosts = allPosts.filter((post) => !post.data.draft);
 
 	return publishedPosts.map((post) => {
-		// 将 id 转换为 slug（移除扩展名）以匹配路由参数
-		const slug = removeFileExtension(post.id);
+		// 将 .png 作为 catch-all 参数的一部分，避免 Astro 对
+		// [...slug].png.ts 生成的严格后缀路由无法匹配尾斜杠路径。
+		const slug = `${removeFileExtension(post.id)}.png`;
 		return {
 			params: { slug },
 			props: { post },


### PR DESCRIPTION
## 变更内容

修复中文等非 ASCII slug 下 OG 图片 endpoint 在 Astro 7 静态构建时可能触发 `NoMatchingStaticPathFound` 的问题。

具体改动：

- 将 `src/pages/og/[...slug].png.ts` 改为 `src/pages/og/[...slug].ts`
- 在 `getStaticPaths()` 中把 `.png` 后缀合入 catch-all `slug` 参数

## 原因

原文件名 `[...slug].png.ts` 会让 Astro 生成严格匹配 `.png` 结尾的 endpoint route pattern。若静态构建阶段在 `trailingSlash: "always"` 下把非 ASCII 图片链接规范化为 `.png/`，该 route pattern 无法匹配尾斜杠路径，导致 params 提取失败并触发 `NoMatchingStaticPathFound`。

把 `.png` 移入 catch-all 参数后，endpoint 可以匹配 `/og/中文路径.png/`，最终静态产物仍会正确写为 `.png` 文件。

Fixes #500

## 验证

```text
pnpm install --frozen-lockfile
pnpm exec astro build
pnpm exec astro check
```

结果：构建通过，Astro check 为 0 errors / 0 warnings / 0 hints。
