### PR TITLE
fix(font): 修复 Astro Font API 组合字体变量的 CJK 回退

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -55,7 +55,11 @@ export default defineConfig({
 					},
 				],
 			},
-			fallbacks: ["sans-serif"],
+			// These variables are composed into --font-sans below. Keep their
+			// fallback lists empty; otherwise a system fallback after this Latin
+			// font prevents the following CJK font from ever being considered.
+			fallbacks: [],
+			optimizedFallbacks: false,
 		},
 		{
 			name: "Loli",
@@ -70,7 +74,10 @@ export default defineConfig({
 					},
 				],
 			},
-			fallbacks: ["sans-serif"],
+			// The final system fallback belongs to --font-sans, not this partial
+			// CJK font stack.
+			fallbacks: [],
+			optimizedFallbacks: false,
 		},
 	],
 


### PR DESCRIPTION
## 问题

Astro Font API 为 `--font-body` 和 `--font-cjk` 分别生成完整的 fallback 链。主题再通过下列配置组合它们：

```css
--font-sans: var(--font-body), var(--font-cjk), ui-sans-serif, system-ui, sans-serif;
```

展开后，`--font-body` 自带的 `sans-serif` 会在 `--font-cjk` 之前生效。当英文字体缺少中文字符时，浏览器会直接回退到系统字体，而不会继续尝试 CJK 字体，导致“英文优先 ZenMaru、中文优先 Loli”的配置失效。

## 解决方案

保留 Astro Font API 的字体加载、指纹化和预加载能力，但让两个待组合的 CSS 变量仅表示各自的字体：

- 将 `fallbacks` 设为 `[]`；
- 将 `optimizedFallbacks` 设为 `false`，避免生成度量优化后的本地 fallback；
- 最终系统字体回退继续只由 `--font-sans` 统一提供。

这样最终字体顺序变为：

```text
ZenMaruGothic → Loli → ui-sans-serif → system-ui → sans-serif
```

## 验证

- `pnpm exec astro check`：0 errors、0 warnings。
- 构建产物中 `--font-body` 与 `--font-cjk` 均只包含对应的 Astro 字体名。
- 使用 ZenMaru 缺失、但 Loli 包含的中文字符进行本地对照：修复前落入系统字体，修复后正确使用 Loli。

Related to #489