### PR TITLE
fix(pio): 修复 iframe 透明区域遮挡页面点击

### DIFF
--- a/public/pio/live2d-host.html
+++ b/public/pio/live2d-host.html
@@ -12,7 +12,12 @@
   var widgetInstance = null;
   var activeConfigKey = '';
   var loadingConfigKey = '';
+  var widgetLoaded = false;
+  var baseContentHeight = 500;
   var lastContentHeight = 500;
+  var floatingContentPadding = 12;
+  var layoutObserver = null;
+  var layoutFrame = 0;
 
   var menuActions = {
     home: function() { parent.postMessage({ type: 'l2d-action', action: 'home' }, '*'); },
@@ -21,18 +26,57 @@
   };
 
   function notifyLoaded() {
-    var maxBottom = 0;
-    document.querySelectorAll('*').forEach(function(el) {
-      if (el.getBoundingClientRect) {
-        var r = el.getBoundingClientRect();
-        if (r.width > 0 && r.height > 0 && r.bottom > maxBottom) {
-          maxBottom = r.bottom;
-        }
-      }
+    parent.postMessage({ type: 'l2d-loaded', contentHeight: lastContentHeight }, '*');
+  }
+
+  function getWidgetHeight(size) {
+    if (typeof size === 'number') return size;
+    if (size && typeof size.height === 'number') return size.height;
+    return 500;
+  }
+
+  function measureContentHeight() {
+    if (!widgetLoaded) return;
+
+    var viewportHeight = window.innerHeight;
+    var minTop = viewportHeight - baseContentHeight;
+    document.body.querySelectorAll('*').forEach(function(el) {
+      if (!el.getBoundingClientRect || /^(SCRIPT|STYLE)$/.test(el.tagName)) return;
+      var style = getComputedStyle(el);
+      if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0) return;
+      var paintsBox =
+        !/^(transparent|rgba\(0, 0, 0, 0\))$/.test(style.backgroundColor) ||
+        style.backgroundImage !== 'none' ||
+        style.boxShadow !== 'none';
+      if (!paintsBox) return;
+      var rect = el.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0 && rect.top < minTop) minTop = rect.top;
     });
 
-    lastContentHeight = Math.ceil(maxBottom) || lastContentHeight || 500;
-    parent.postMessage({ type: 'l2d-loaded', contentHeight: lastContentHeight }, '*');
+    var measuredHeight = Math.ceil(viewportHeight - minTop);
+    var nextHeight = measuredHeight > baseContentHeight
+      ? measuredHeight + floatingContentPadding
+      : baseContentHeight;
+    if (nextHeight === lastContentHeight) return;
+    lastContentHeight = nextHeight;
+    notifyLoaded();
+  }
+
+  function scheduleLayoutMeasurement() {
+    cancelAnimationFrame(layoutFrame);
+    layoutFrame = requestAnimationFrame(measureContentHeight);
+  }
+
+  function observeWidgetLayout() {
+    if (layoutObserver) layoutObserver.disconnect();
+    layoutObserver = new MutationObserver(scheduleLayoutMeasurement);
+    layoutObserver.observe(document.body, {
+      subtree: true,
+      childList: true,
+      characterData: true,
+      attributes: true,
+      attributeFilter: ['class', 'style'],
+    });
   }
 
   function hideAboutMenu() {
@@ -51,6 +95,10 @@
       console.error('Failed to destroy Live2D widget:', err);
     }
     widgetInstance = null;
+    widgetLoaded = false;
+    if (layoutObserver) layoutObserver.disconnect();
+    layoutObserver = null;
+    cancelAnimationFrame(layoutFrame);
   }
 
   window.addEventListener('message', function(e) {
@@ -59,7 +107,7 @@
     var configKey = JSON.stringify(config);
 
     if (widgetInstance && activeConfigKey === configKey) {
-      notifyLoaded();
+      if (widgetLoaded) notifyLoaded();
       return;
     }
 
@@ -85,6 +133,8 @@
     try {
       widgetInstance = L2D_WIDGET.createWidget(config);
       activeConfigKey = configKey;
+      baseContentHeight = getWidgetHeight(config.size);
+      lastContentHeight = baseContentHeight;
     } catch (err) {
       loadingConfigKey = '';
       activeConfigKey = '';
@@ -97,27 +147,15 @@
       hideAboutMenu();
     }
 
-    var notified = false;
-    function notifyOnce() {
-      if (notified) return;
-      notified = true;
+    widgetInstance.l2d.on('loaded', function() {
+      widgetLoaded = true;
       notifyLoaded();
-    }
-
-    var checkInterval = setInterval(function() {
-      var canvas = document.querySelector('canvas');
-      if (canvas && canvas.width > 0 && canvas.height > 0) {
-        clearInterval(checkInterval);
-        setTimeout(notifyOnce, 300);
-      }
-    }, 200);
-
-    setTimeout(function() {
-      clearInterval(checkInterval);
-      loadingConfigKey = '';
-      notifyOnce();
-    }, 15000);
+      observeWidgetLayout();
+      scheduleLayoutMeasurement();
+    });
   });
+
+  window.addEventListener('resize', scheduleLayoutMeasurement);
 </script>
 </body>
 </html>

--- a/src/components/features/pio/Pio.astro
+++ b/src/components/features/pio/Pio.astro
@@ -82,6 +82,7 @@ const isRight = config.position === "right";
 	};
 
 	const win = window as Window & { __mizukiPioController?: PioController };
+	const PIO_MOBILE_BREAKPOINT = 768;
 	const scriptEl = document.currentScript as HTMLScriptElement | null;
 	const renderedEl =
 		scriptEl?.previousElementSibling instanceof HTMLIFrameElement &&
@@ -119,7 +120,10 @@ const isRight = config.position === "right";
 
 			function applyVisibility() {
 				if (!currentEl) return;
-				if (currentHiddenOnMobile && window.innerWidth <= 1280) {
+				if (
+					currentHiddenOnMobile &&
+					window.innerWidth <= PIO_MOBILE_BREAKPOINT
+				) {
 					currentEl.style.display = "none";
 				} else {
 					currentEl.style.display = "";
@@ -128,7 +132,11 @@ const isRight = config.position === "right";
 
 			function postInit() {
 				if (!currentEl || initSent || isTransitioning) return;
-				if (currentHiddenOnMobile && window.innerWidth <= 1280) return;
+				if (
+					currentHiddenOnMobile &&
+					window.innerWidth <= PIO_MOBILE_BREAKPOINT
+				)
+					return;
 				currentEl.contentWindow?.postMessage(
 					{ type: "l2d-init", config: currentConfig },
 					"*",

--- a/vercel.json
+++ b/vercel.json
@@ -26,6 +26,15 @@
 			]
 		},
 		{
+			"source": "/pio/live2d-host",
+			"headers": [
+				{
+					"key": "X-Frame-Options",
+					"value": "SAMEORIGIN"
+				}
+			]
+		},
+		{
 			"source": "/_astro/(.*)",
 			"headers": [
 				{


### PR DESCRIPTION
﻿﻿## 变更类型

- [x] Bug 修复（修复问题的非破坏性变更）
- [ ] 新功能（新增功能的非破坏性变更）
- [ ] 破坏性变更（会导致既有功能无法按预期工作的修复或功能）
- [ ] 其他（请说明）

## 检查清单

- [x] 我已阅读贡献指南。
- [x] 我已确认此 Pull Request 不包含个人化改动。
- [x] 我已完成代码自检。
- [x] 本次改动未产生新的警告。

## 关联 Issue

Closes #507

## 问题原因

看板娘 iframe 初始高度为 600px。原有 `notifyLoaded` 会遍历 iframe 内的全部元素，并用最大的 `getBoundingClientRect().bottom` 作为内容高度；但 `html`、`body` 以及 `position: fixed; bottom: 0` 的看板娘容器会始终跟随 iframe 视口，因此测量结果一直等于当前 600px 高度。

父页面无法在模型完成加载后收缩 iframe，最终造成页面左侧大面积透明区域持续拦截链接、标签等元素的鼠标事件。

此外，项目的 Vercel 配置为所有页面统一返回 `X-Frame-Options: DENY`，生产环境会直接拒绝同源加载 `/pio/live2d-host`，导致看板娘仅在本地开发环境正常显示。

## 改动内容

- 保留 600px 初始 iframe 视口，确保 `l2d-widget` 正常完成 fixed 布局、WebGL 初始化和模型加载。
- 监听 `widgetInstance.l2d` 的真实 `loaded` 事件，仅在模型确实加载完成后通知父页面。
- 根据公开的 `size` 配置计算确定高度，兼容数值和 `{ width, height }` 两种形式。
- 模型加载完成后，将 iframe 从初始的 `280 × 600` 收缩为基础尺寸 `280 × 280`，从布局盒层面消除透明点击拦截区域。`MutationObserver` 会继续跟踪气泡和菜单的可见状态：气泡出现时按实际占用高度临时扩展，隐藏后自动收回。
- 删除受 `html`、`body` 和 fixed 元素影响的全 DOM 自动测高逻辑，以及基于 canvas 创建状态的提前通知轮询。
- 在模型重复初始化和销毁时同步维护加载状态。
- 为 Vercel clean URL `/pio/live2d-host` 单独设置 `X-Frame-Options: SAMEORIGIN`；其他页面继续保留 `DENY` 防护。
- 将移动端隐藏阈值调整为 768px，避免高 DPI 桌面窗口被误判为移动设备。

## 测试方式

已执行并通过：

```bash
pnpm type-check
pnpm exec astro check
pnpm build
```

结果：

- Astro 检查：314 个文件，0 errors、0 warnings、0 hints。
- 完整生产构建成功，25 个页面生成完成。
- Vercel 宿主页返回 `X-Frame-Options: SAMEORIGIN`。
- 模型加载完成后，iframe 从 `280 × 600` 收缩为 `280 × 280`；对话气泡显示时动态扩展，隐藏后恢复基础高度。
- 看板娘本体、菜单和对话气泡保持正常显示与交互，其上方原先被遮挡的页面内容恢复正常悬停与点击。

## 在线演示

<https://mizuki-red-three.vercel.app/>

## 其他说明

本 PR 不修改 `l2d-widget.min.js` 或第三方依赖源码，仅调整 Mizuki 的 iframe 适配层与 Vercel 响应头配置。


## 针对气泡空间反馈的补充

Issue 讨论中进一步指出：如果模型加载后直接把 iframe 固定收缩为 `280 × 280`，位于模型容器上方的对话气泡会因为没有预留空间而被 iframe 边界裁切。

本 PR 已补充动态浮层高度处理：

- 使用 `MutationObserver` 监听气泡和菜单的内容、样式及可见状态变化；
- 以 iframe 底部为基准计算可见浮层实际向上占用的距离；
- 气泡出现时临时扩展 iframe，隐藏后恢复模型基础高度；
- 对超出模型区域的浮层额外增加 `12px` 安全余量，覆盖气泡约 `5px` 的上浮动画和边缘抗锯齿空间；
- 没有气泡时不保留额外透明区域，因此不会重新引入页面点击拦截。

在线部署已确认气泡完整显示、模型交互正常，气泡隐藏后 iframe 点击范围会自动收回。
