### PR TITLE
fix(layout): 修复 Fullscreen 模式 sidebar 吸顶偏移

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "type-check": "tsc --noEmit",
-    "test": "node --test tests/markdown-enhancements.test.mjs && node tests/crypto.test.mjs",
+    "test": "node --test tests/markdown-enhancements.test.mjs tests/layout-regressions.test.mjs && node tests/crypto.test.mjs",
     "new-post": "node scripts/new-post.js",
     "format": "biome format --write ./src",
     "lint": "biome check --write ./src",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -292,13 +292,15 @@ const bannerOffset =
 	}
 	@layer utilities {
 		@media (width >= 1280px) {
-			.enable-banner #sidebar-sticky {
+			/* Fullscreen removes the banner extension transform, so only the
+			   standard banner layout needs the matching sticky compensation. */
+			.enable-banner:not(.fullscreen-banner) #sidebar-sticky {
 				top: calc(1rem - var(--banner-height-extend)) !important;
 			}
-			.enable-banner #left-sidebar-sticky {
+			.enable-banner:not(.fullscreen-banner) #left-sidebar-sticky {
 				top: calc(1rem - var(--banner-height-extend)) !important;
 			}
-			.enable-banner #right-sidebar-sticky {
+			.enable-banner:not(.fullscreen-banner) #right-sidebar-sticky {
 				top: calc(1rem - var(--banner-height-extend)) !important;
 			}
 		}

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { describe, it } from "node:test";
+
+const layoutSource = await readFile(
+	new URL("../src/layouts/Layout.astro", import.meta.url),
+	"utf8",
+);
+const bannerStyles = await readFile(
+	new URL("../src/styles/banner.css", import.meta.url),
+	"utf8",
+);
+
+describe("Fullscreen banner layout regressions", () => {
+	it("does not apply the standard banner sticky compensation in fullscreen", () => {
+		assert.match(
+			bannerStyles,
+			/body\.enable-banner\.fullscreen-banner #main-grid\s*\{[^}]*transform:\s*translateY\(0\)/s,
+			"fullscreen must continue to remove the banner extension transform",
+		);
+
+		for (const stickyId of [
+			"sidebar-sticky",
+			"left-sidebar-sticky",
+			"right-sidebar-sticky",
+		]) {
+			assert.ok(
+				layoutSource.includes(
+					`.enable-banner:not(.fullscreen-banner) #${stickyId}`,
+				),
+				`${stickyId} must exclude fullscreen from the banner offset compensation`,
+			);
+			assert.ok(
+				!layoutSource.includes(`.enable-banner #${stickyId}`),
+				`${stickyId} must not use the unscoped banner offset compensation`,
+			);
+		}
+	});
+});


### PR DESCRIPTION
## 变更类型

- [x] Bug 修复（修复问题的非破坏性变更）
- [ ] 新功能（新增功能的非破坏性变更）
- [ ] 破坏性变更（会导致既有功能无法按预期工作的修复或功能）
- [ ] 其他（请说明）

## 检查清单

- [x] 我已检查仓库现有贡献约定与近期 PR 格式。
- [x] 我已确认此 Pull Request 不包含个人化改动。
- [x] 我已完成代码自检、构建验证和浏览器交互验证。
- [x] 本次改动未产生新的错误或警告。

## 关联 Issue

Closes #511

## 问题原因

桌面端普通 Banner 布局会将主网格向下平移
`--banner-height-extend`（约 `30vh`）。为了让 sidebar 卡片最终仍吸附在距
视口顶部 `1rem` 的位置，现有全局样式对三个 sticky 容器设置了相反方向
的补偿：

```css
.enable-banner #sidebar-sticky,
.enable-banner #left-sidebar-sticky,
.enable-banner #right-sidebar-sticky {
  top: calc(1rem - var(--banner-height-extend)) !important;
}
```

切换到 Fullscreen Wallpaper 后，运行时会同时添加 `enable-banner` 和
`fullscreen-banner`。Fullscreen 专用布局已经通过以下规则清除了主网格
位移：

```css
body.enable-banner.fullscreen-banner #main-grid {
  transform: translateY(0) !important;
}
```

但是 sidebar 的补偿选择器只判断 `enable-banner`，因此仍然命中。主网格
不再有 `30vh` 位移，sticky 的 `top` 却继续减去同样的高度，最终得到
负值。滚动长页面时，左右 sidebar 卡片会吸附到视口上方并被裁切。

这是全局布局状态与补偿条件不匹配，所以文章页、`/timeline` 等所有长内容
页面都可能复现，且控制台不会出现脚本错误。

## 修复内容

### 1. 将 sticky 补偿限定到普通 Banner 模式

三个 sidebar 选择器增加 `:not(.fullscreen-banner)`：

```css
.enable-banner:not(.fullscreen-banner) #sidebar-sticky,
.enable-banner:not(.fullscreen-banner) #left-sidebar-sticky,
.enable-banner:not(.fullscreen-banner) #right-sidebar-sticky {
  top: calc(1rem - var(--banner-height-extend)) !important;
}
```

这样：

- 普通 Banner 模式继续保留原有位移补偿，现有布局行为不变；
- Fullscreen 模式不再应用已经失去对应网格位移的负补偿；
- Fullscreen 下 sticky 容器自然回退到组件已有的 `top-4`（`1rem`）；
- 不增加 JS 内联样式、事件监听或强制重排，避免模式切换和 Swup
  导航时序依赖。

### 2. 增加布局回归测试

新增 `tests/layout-regressions.test.mjs`，验证：

- Fullscreen 仍明确清除 `#main-grid` 位移；
- 左侧、右侧及兼容保留的 sticky ID 都显式排除 Fullscreen；
- 不允许重新引入未限定状态的 `.enable-banner #*-sidebar-sticky` 规则。

同时将该测试接入现有 `pnpm test` 脚本。

## 自动化验证

已执行并通过：

```bash
pnpm test
pnpm exec biome check src/layouts/Layout.astro tests/layout-regressions.test.mjs
pnpm check
pnpm exec astro build
```

结果：

- Node 测试 9 项、加密测试 8 项，共 17 项全部通过；
- 本次改动的布局文件和测试文件通过 Biome 检查；
- Astro Check 检查 317 个文件，0 errors、0 warnings、0 hints；
- Astro 生产构建成功，共生成 25 个页面；
- 构建产物中的三个选择器被正确合并为
  `.enable-banner:not(.fullscreen-banner) ...`，状态限定在
  Astro/Tailwind 编译后仍然有效。

## 手动浏览器验证

已在桌面 Chromium 浏览器中对本地 production preview 进行真实交互
验证，页面内容视口为 `1751 × 1290`。验证覆盖普通 Banner、运行时切换
Fullscreen、刷新后保留 Fullscreen，以及 Issue 中报告的文章页和
`/timeline`。

### 普通 Banner 回归

在长内容区域滚动后：

- `<body>` 包含 `enable-banner`，不包含 `fullscreen-banner`；
- `#main-grid` 保留与 `--banner-height-extend` 对应的纵向位移；
- sidebar sticky 保留普通 Banner 所需的负 `top` 补偿；
- 右侧 sticky 的最终 `rectTop` 约为当前页面 `1rem`；
- 左右卡片顶部完整，原有吸顶行为未被本次修复改变。

### Fullscreen 运行时切换

切换到 Fullscreen Wallpaper 后确认：

```text
storedMode: fullscreen
bodyClasses: ... enable-banner ... fullscreen-banner
mainGridTransform: matrix(1, 0, 0, 1, 0, 0)
```

主网格的纵向位移已归零，三个 sidebar 选择器不再应用普通 Banner 的
负补偿。

### 文章页

在 `/posts/markdown-tutorial/`、`scrollY = 2100` 时测得：

| 元素 | position | computedTop | rectTop | rectBottom |
| --- | --- | ---: | ---: | ---: |
| `#sidebar-sticky` | sticky | 14.008px | 14.00px | 720.52px |
| `#right-sidebar-sticky` | sticky | 14.008px | 14.00px | 386.22px |

左右 sticky 的实际视口位置与计算后的 `top: 1rem` 一致，卡片顶部完整，
没有裁切或偏移。

### Timeline 与刷新持久化

保持 Fullscreen 并刷新后，`localStorage.getItem("wallpaperMode")` 仍返回
`fullscreen`。在 `/timeline`、`scrollY = 2100` 时测得：

| 元素 | position | computedTop | rectTop | rectBottom |
| --- | --- | ---: | ---: | ---: |
| `#sidebar-sticky` | sticky | 14.008px | 14.00px | 156.06px |
| `#right-sidebar-sticky` | sticky | 14.008px | 14.00px | 386.22px |

左右 sticky 同样稳定吸附在约 `1rem` 的位置，刷新持久化和跨页面行为
均正常。

验证期间出现的 lazy-loading、forced reflow 和本地 Pagefind 索引缺失提示
与 sidebar 定位无关；没有发现 sidebar 或 Wallpaper 模式切换相关的
运行时错误。

综上，#511 中列出的普通 Banner 回归、Fullscreen 切换、文章页、Timeline
以及刷新持久化场景均验证通过。

## 在线预览

[Vercel](https://mizuki-7l3cv0aav-dawns-projects-37e0287f.vercel.app/posts/markdown-tutorial/)

## 浏览器验证截图

### 普通 Banner 模式未发生回归

<img width="2560" height="1439" alt="普通 Banner 模式未发生回归" src="https://github.com/user-attachments/assets/9985f635-6f12-408b-ba29-3430970b0c7e" />

### Fullscreen Timeline 与刷新持久化
<img width="2518" height="1290" alt="Fullscreen Timeline 与刷新持久化" src="https://github.com/user-attachments/assets/7418976a-23ef-40e6-b4d4-601e727e33c9" />

### Fullscreen 文章页
<img width="2560" height="1400" alt="Fullscreen 文章页" src="https://github.com/user-attachments/assets/ac469ed6-4371-496d-973f-a8e78d79c9ec" />


## 其他说明

- 本 PR 不修改依赖或锁文件；
- 不改变 Wallpaper 模式切换逻辑；
- 不改变 sidebar 组件结构和卡片配置；
- 修复仅收紧普通 Banner 位移补偿的适用范围，并增加对应回归保护。
