### PR TITLE
docs: Update README to reflect config file path change

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ All commands are run from the project root:
 
 ### 🔧 Basic Configuration
 
-Edit `src/config.ts` to customize your blog:
+Edit `src/config/siteConfig.ts` to customize your blog:
 
 ```typescript
 export const siteConfig: SiteConfig = {


### PR DESCRIPTION
在"README.md"中将"配置指南"中对于配置文件的路径做出修改，将"src/config.ts"改为"src/config/siteConfig.ts"

## 变更类型

- [ ] Bug 修复（修复问题的非破坏性变更）
- [ ] 新功能（新增功能的非破坏性变更）
- [ ] 破坏性变更（会导致既有功能无法按预期工作的修复或功能）
- [x] 其他 : 对于README文档的修改

## 检查清单

- [x] 我已阅读贡献指南。
- [x] 我已确认此 Pull Request 不包含个人化改动。
- [x] 我已完成代码自检。
- [x] 本次改动未产生新的警告。

## 关联 Issue

无

## 更改内容

在现版本(Mizuki v9.0)的`src`路径下不存在`config.ts`文件，而以下内容在`src/config/siteConfig.ts`中
```typescript
export const siteConfig: SiteConfig = {
  title: "您的博客名称",
  subtitle: "您的博客描述",
  lang: "zh-CN", // 或 "en"、"ja" 等
  themeColor: {
    hue: 210, // 0-360，主题色调
    fixed: false, // 隐藏主题色选择器
  },
  banner: {
    enable: true,
    src: ["assets/banner/1.webp"], // 横幅图片
    carousel: {
      enable: true,
      interval: 0.8, // 秒
    },
  },
};
```

在"README.md"中将"配置指南"中对于配置文件的路径做出修改，将"src/config.ts"改为"src/config/siteConfig.ts"
