### PR TITLE
docs(license): 补充 Firefly MIT 归属与第三方声明

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,10 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 This project is based on [Fuwari](https://github.com/saicaca/fuwari), which is licensed under the MIT License. The original copyright notice and permission notice are included in the LICENSE.MIT file in accordance with the MIT License requirements.
 
+### Third-Party Notices
+
+Portions of the Markdown enhancements are adapted from [Firefly](https://github.com/CuteLeaf/Firefly) under the MIT License. The original copyright and complete license text are retained in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+
 ## 🙏 Acknowledgements
 
 - Based on the original [Fuwari](https://github.com/saicaca/fuwari) template

--- a/README.zh.md
+++ b/README.zh.md
@@ -353,6 +353,10 @@ pnpm run sync-content
 
 本项目基于 [Fuwari](https://github.com/saicaca/fuwari) 开发，该项目使用 MIT 许可证。根据 MIT 许可证要求，原始版权声明和许可声明已包含在 LICENSE.MIT 文件中。
 
+### 第三方软件声明
+
+Markdown 增强功能的部分实现基于 [Firefly](https://github.com/CuteLeaf/Firefly) 的 MIT 许可代码改写。原始版权声明与完整许可证文本保留在 [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) 中。
+
 ## 🙏 致谢
 
 - 基于原始 [Fuwari](https://github.com/saicaca/fuwari) 模板

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,44 @@
+# Third-Party Notices
+
+This project includes portions adapted from the following open-source project.
+
+## Firefly
+
+- Source: https://github.com/CuteLeaf/Firefly
+- License: MIT License
+- Usage: Markdown code groups, Wiki Link processing, PlantUML rendering and related interaction/styles were adapted and modified for Mizuki.
+
+The affected files are:
+
+- `src/components/features/markdown/CodeGroupManager.astro`
+- `src/components/features/markdown/DiagramManager.astro`
+- `src/plugins/remark-wiki-link.mjs`
+- `src/plugins/plantuml-encoder.mjs`
+- `src/plugins/remark-plantuml.mjs`
+- `src/plugins/rehype-plantuml.mjs`
+- The `rehype-code-group` section in `src/styles/expressive-code.css`
+
+### Firefly MIT License
+
+MIT License
+
+Copyright (c) 2024 saicaca  
+Copyright (c) 2025 CuteLeaf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/components/features/markdown/CodeGroupManager.astro
+++ b/src/components/features/markdown/CodeGroupManager.astro
@@ -1,4 +1,9 @@
 ---
+// Portions adapted from https://github.com/CuteLeaf/Firefly
+// Copyright (c) 2024 saicaca
+// Copyright (c) 2025 CuteLeaf
+// Licensed under the MIT License. See THIRD_PARTY_NOTICES.md.
+//
 // rehype-code-group 的原生脚本依赖首次 DOMContentLoaded。使用事件委托后，
 // Swup 替换 main 内容无需重新绑定。
 ---

--- a/src/components/features/markdown/DiagramManager.astro
+++ b/src/components/features/markdown/DiagramManager.astro
@@ -1,4 +1,9 @@
 ---
+// Portions adapted from https://github.com/CuteLeaf/Firefly
+// Copyright (c) 2024 saicaca
+// Copyright (c) 2025 CuteLeaf
+// Licensed under the MIT License. See THIRD_PARTY_NOTICES.md.
+//
 // PlantUML 图表主题、缩放、拖拽和全屏交互。所有监听均使用事件委托或
 // 幂等初始化，以兼容 Swup 页面切换与加密文章解密后的动态内容。
 ---

--- a/src/plugins/plantuml-encoder.mjs
+++ b/src/plugins/plantuml-encoder.mjs
@@ -1,3 +1,8 @@
+// Portions adapted from https://github.com/CuteLeaf/Firefly
+// Copyright (c) 2024 saicaca
+// Copyright (c) 2025 CuteLeaf
+// Licensed under the MIT License. See THIRD_PARTY_NOTICES.md.
+
 import * as pako from "pako";
 
 const ALPHABET =

--- a/src/plugins/rehype-plantuml.mjs
+++ b/src/plugins/rehype-plantuml.mjs
@@ -1,3 +1,8 @@
+// Portions adapted from https://github.com/CuteLeaf/Firefly
+// Copyright (c) 2024 saicaca
+// Copyright (c) 2025 CuteLeaf
+// Licensed under the MIT License. See THIRD_PARTY_NOTICES.md.
+
 import { h } from "hastscript";
 import { visit } from "unist-util-visit";
 

--- a/src/plugins/remark-plantuml.mjs
+++ b/src/plugins/remark-plantuml.mjs
@@ -1,3 +1,8 @@
+// Portions adapted from https://github.com/CuteLeaf/Firefly
+// Copyright (c) 2024 saicaca
+// Copyright (c) 2025 CuteLeaf
+// Licensed under the MIT License. See THIRD_PARTY_NOTICES.md.
+
 import { visit } from "unist-util-visit";
 import {
 	encodePlantUML,

--- a/src/plugins/remark-wiki-link.mjs
+++ b/src/plugins/remark-wiki-link.mjs
@@ -1,3 +1,8 @@
+// Portions adapted from https://github.com/CuteLeaf/Firefly
+// Copyright (c) 2024 saicaca
+// Copyright (c) 2025 CuteLeaf
+// Licensed under the MIT License. See THIRD_PARTY_NOTICES.md.
+
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/src/styles/expressive-code.css
+++ b/src/styles/expressive-code.css
@@ -219,7 +219,13 @@
     display: none !important;
   }
 }
-/* Tab 代码组（rehype-code-group） */
+/*
+ * Tab 代码组（rehype-code-group）
+ * Portions adapted from https://github.com/CuteLeaf/Firefly
+ * Copyright (c) 2024 saicaca
+ * Copyright (c) 2025 CuteLeaf
+ * Licensed under the MIT License. See THIRD_PARTY_NOTICES.md.
+ */
 .rehype-code-group {
 	margin: 1.5rem 0;
 	border-radius: var(--radius-large);


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other: 补充第三方代码来源、版权归属与许可证声明

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue / PR

- Follow-up to #513
- 回应 #513 中关于 Firefly MIT 许可证归属的提醒：https://github.com/LyraVoid/Mizuki/pull/513#issuecomment-5150507264

## Changes

- 新增根目录 `THIRD_PARTY_NOTICES.md`：
  - 明确 Markdown 代码组、Wiki Link、PlantUML 渲染和相关交互/样式包含基于 Firefly 改写的部分。
  - 列出所有受影响文件。
  - 完整保留 Firefly 的来源链接、版权信息和 MIT License 全文。
- 在以下源码加入 Firefly 来源、版权和 MIT 许可声明：
  - `CodeGroupManager.astro`
  - `DiagramManager.astro`
  - `remark-wiki-link.mjs`
  - `plantuml-encoder.mjs`
  - `remark-plantuml.mjs`
  - `rehype-plantuml.mjs`
- 仅在 `expressive-code.css` 的代码组样式段落标注来源，避免将无关样式错误归属于第三方。
- 在中英文 README 的许可证章节增加第三方声明入口。

## Additional Notes

- Mizuki 继续以 Apache-2.0 作为项目主许可证。
- Firefly 的 MIT License 仅适用于明确参考或改写的相关部分。
- 现有 `LICENSE.MIT` 保留 Fuwari 的原始 MIT 声明；Firefly 的完整声明独立保存在 `THIRD_PARTY_NOTICES.md`，避免混淆不同来源。