### PR TITLE
fix(style): 修复 #527 导致的首页全局样式缺失

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "update-anime": "node scripts/update-anime.mjs",
     "update-bangumi": "node scripts/update-bangumi.mjs",
     "update-bilibili": "node scripts/update-bilibili.mjs",
-    "build": "node scripts/update-anime.mjs && astro build && pagefind --site dist",
+    "build": "node scripts/update-anime.mjs && astro build && node scripts/check-global-style-loading.mjs && pagefind --site dist",
     "submit": "node scripts/indexnow-submit.js",
     "preview": "astro preview",
     "astro": "astro",

--- a/scripts/check-global-style-loading.mjs
+++ b/scripts/check-global-style-loading.mjs
@@ -1,0 +1,80 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+);
+const distDirectory = path.join(projectRoot, "dist");
+const indexPath = path.join(distDirectory, "index.html");
+const indexHtml = await readFile(indexPath, "utf8");
+
+function getAttribute(tag, name) {
+	const match = tag.match(
+		new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`, "i"),
+	);
+	return match?.[1] ?? match?.[2] ?? match?.[3];
+}
+
+const stylesheetUrls = [...indexHtml.matchAll(/<link\b[^>]*>/gi)]
+	.map(([tag]) => ({
+		href: getAttribute(tag, "href"),
+		rel: getAttribute(tag, "rel"),
+	}))
+	.filter(
+		({ href, rel }) =>
+			href && rel?.split(/\s+/).some((value) => value === "stylesheet"),
+	)
+	.map(({ href }) => href);
+
+const inlineStyles = [
+	...indexHtml.matchAll(/<style\b[^>]*>([\s\S]*?)<\/style>/gi),
+]
+	.map((match) => match[1])
+	.join("\n");
+
+const linkedStyles = await Promise.all(
+	stylesheetUrls.map(async (stylesheetUrl) => {
+		const pathname = decodeURIComponent(stylesheetUrl.split(/[?#]/, 1)[0]);
+		if (/^(?:[a-z]+:)?\/\//i.test(pathname) || pathname.startsWith("data:")) {
+			return "";
+		}
+
+		const assetPath = path.resolve(
+			distDirectory,
+			pathname.startsWith("/") ? pathname.slice(1) : pathname,
+		);
+		const relativePath = path.relative(distDirectory, assetPath);
+		if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+			throw new Error(`Stylesheet escapes dist directory: ${stylesheetUrl}`);
+		}
+
+		return readFile(assetPath, "utf8");
+	}),
+);
+
+const loadedCss = `${inlineStyles}\n${linkedStyles.join("\n")}`;
+const requiredRules = [
+	["--page-bg:", "page background variable"],
+	["--card-bg:", "card background variable"],
+	["--radius-large:", "shared radius variable"],
+	["#banner-carousel", "banner layout styles"],
+	[".widget-container", "responsive widget styles"],
+];
+const missingRules = requiredRules
+	.filter(([token]) => !loadedCss.includes(token))
+	.map(([, description]) => description);
+
+if (missingRules.length > 0) {
+	const loadedStylesheets = stylesheetUrls.join(", ") || "none";
+	throw new Error(
+		`Homepage is missing global styles: ${missingRules.join(", ")}. ` +
+			`Loaded stylesheets: ${loadedStylesheets}`,
+	);
+}
+
+console.log(
+	"Verified homepage global styles across " +
+		`${stylesheetUrls.length} linked stylesheet(s).`,
+);

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,7 +13,11 @@ const BANNER_HEIGHT_EXTEND = 30;
 const BANNER_HEIGHT_HOME = BANNER_HEIGHT + BANNER_HEIGHT_EXTEND;
 
 import { PAGE_WIDTH } from "../constants/constants";
+import "../styles/variables.styl";
 import "../styles/main.css";
+import "../styles/banner.css";
+import "../styles/transition.css";
+import "../styles/widget-responsive.css";
 import "../styles/mobile-navbar.css";
 import "../styles/wallpaper-navbar-transparent.css";
 import "../styles/fancybox-custom.css";

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4,13 +4,9 @@
 @import "./albums.css";
 /* 导入追番页面样式 */
 @import "./anime.css";
-/* 导入动画样式 */
-@import "./transition.css";
 @import "./animation-enhancements.css";
 /* 导入渐变按钮样式 */
 @import "./gradient-buttons.css";
-/* 导入 Banner 和网格布局样式 */
-@import "./banner.css";
 /* 加密内容样式已移除，现在直接使用非加密文章的样式 */
 
 @plugin "@tailwindcss/typography";

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -10,6 +10,38 @@ const bannerStyles = await readFile(
 	new URL("../src/styles/banner.css", import.meta.url),
 	"utf8",
 );
+const mainStyles = await readFile(
+	new URL("../src/styles/main.css", import.meta.url),
+	"utf8",
+);
+const packageConfig = JSON.parse(
+	await readFile(new URL("../package.json", import.meta.url), "utf8"),
+);
+
+describe("Global style loading regressions", () => {
+	it("loads shared styles from the root layout and verifies the build output", () => {
+		for (const stylesheet of [
+			"variables.styl",
+			"banner.css",
+			"transition.css",
+			"widget-responsive.css",
+		]) {
+			assert.ok(
+				layoutSource.includes(`import "../styles/${stylesheet}";`),
+				`${stylesheet} must be an explicit root layout dependency`,
+			);
+		}
+
+		assert.doesNotMatch(
+			mainStyles,
+			/@import\s+["']\.\/(?:banner|transition)\.css/,
+		);
+		assert.match(
+			packageConfig.scripts.build,
+			/node scripts\/check-global-style-loading\.mjs/,
+		);
+	});
+});
 
 describe("Fullscreen banner layout regressions", () => {
 	it("does not apply the standard banner sticky compensation in fullscreen", () => {


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

修复 #527 合并后暴露出的首页全局样式依赖回归。

## Changes

- 根因：原 `Image.astro` 中过宽的 `import.meta.glob("../../../**")` 会把 CSS/Stylus 文件意外纳入依赖图；#527 将匹配范围正确收紧为图片扩展名后，首页不再被副作用带入主题变量、Banner、过渡和响应式组件样式。
- 在根 `Layout.astro` 显式导入 `variables.styl`、`banner.css`、`transition.css` 和 `widget-responsive.css`，让全站样式依赖由布局入口明确负责。
- 从 `main.css` 移除 Banner 与过渡样式的嵌套导入，避免同一全局样式存在两套入口及不稳定的分包归属。
- 新增构建产物检查：解析 `dist/index.html` 实际引用的内联样式与哈希 CSS，验证关键主题变量、Banner 布局和响应式组件规则，并将检查接入 `pnpm build`。
- 补充布局回归测试，确保显式全局样式入口和构建检查不会被误删。
- 保留 #527 收紧后的图片 glob，不回退响应式图片优化，也不改变远程 Banner、壁纸、音乐和封面资源的处理方式。

## How To Test

- `pnpm test`：16 项 Node 回归测试和 8 项加密测试全部通过。
- `pnpm astro check`：检查 319 个文件，0 error、0 warning、0 hint。
- `pnpm build`：25 个页面、54 张响应式图片及 Pagefind 索引构建通过；产物检查确认首页加载 11 个样式资源并包含必要全局规则。
- Vercel 在线预览：[点击查看修复效果](https://mizuki-git-fix-pr527-global-styl-f59ebc-dawns-projects-37e0287f.vercel.app/)

## Screenshots (if applicable)

在线预览已确认首页主题颜色、圆角、卡片背景和 Banner 样式恢复正常：
<img width="2514" height="1290" alt="image" src="https://github.com/user-attachments/assets/d3b793af-af16-4aeb-8c5d-fd798e2d5659" />


<img width="2514" height="1290" alt="image" src="https://github.com/user-attachments/assets/9b87fe3c-381c-4aa0-8abc-08fd24848ecf" />


## Additional Notes

此次修复把原先依赖宽泛图片 glob 副作用的隐式 CSS 依赖改为显式全局入口。修复范围集中在根布局、样式入口和回归检查，不恢复宽泛 glob，不影响 #527 的响应式图片与远程资源兼容优化。