### PR TITLE
fix(markdown): 恢复 About 等独立页面的扩展样式

### DIFF
--- a/scripts/check-global-style-loading.mjs
+++ b/scripts/check-global-style-loading.mjs
@@ -7,8 +7,6 @@ const projectRoot = path.resolve(
 	"..",
 );
 const distDirectory = path.join(projectRoot, "dist");
-const indexPath = path.join(distDirectory, "index.html");
-const indexHtml = await readFile(indexPath, "utf8");
 
 function getAttribute(tag, name) {
 	const match = tag.match(
@@ -17,64 +15,104 @@ function getAttribute(tag, name) {
 	return match?.[1] ?? match?.[2] ?? match?.[3];
 }
 
-const stylesheetUrls = [...indexHtml.matchAll(/<link\b[^>]*>/gi)]
-	.map(([tag]) => ({
-		href: getAttribute(tag, "href"),
-		rel: getAttribute(tag, "rel"),
-	}))
-	.filter(
-		({ href, rel }) =>
-			href && rel?.split(/\s+/).some((value) => value === "stylesheet"),
-	)
-	.map(({ href }) => href);
+async function loadPageStyles(htmlPath) {
+	const html = await readFile(path.join(distDirectory, htmlPath), "utf8");
+	const stylesheetUrls = [...html.matchAll(/<link\b[^>]*>/gi)]
+		.map(([tag]) => ({
+			href: getAttribute(tag, "href"),
+			rel: getAttribute(tag, "rel"),
+		}))
+		.filter(
+			({ href, rel }) =>
+				href && rel?.split(/\s+/).some((value) => value === "stylesheet"),
+		)
+		.map(({ href }) => href);
 
-const inlineStyles = [
-	...indexHtml.matchAll(/<style\b[^>]*>([\s\S]*?)<\/style>/gi),
-]
-	.map((match) => match[1])
-	.join("\n");
+	const inlineStyles = [
+		...html.matchAll(/<style\b[^>]*>([\s\S]*?)<\/style>/gi),
+	]
+		.map((match) => match[1])
+		.join("\n");
 
-const linkedStyles = await Promise.all(
-	stylesheetUrls.map(async (stylesheetUrl) => {
-		const pathname = decodeURIComponent(stylesheetUrl.split(/[?#]/, 1)[0]);
-		if (/^(?:[a-z]+:)?\/\//i.test(pathname) || pathname.startsWith("data:")) {
-			return "";
-		}
+	const linkedStyles = await Promise.all(
+		stylesheetUrls.map(async (stylesheetUrl) => {
+			const pathname = decodeURIComponent(stylesheetUrl.split(/[?#]/, 1)[0]);
+			if (
+				/^(?:[a-z]+:)?\/\//i.test(pathname) ||
+				pathname.startsWith("data:")
+			) {
+				return "";
+			}
 
-		const assetPath = path.resolve(
-			distDirectory,
-			pathname.startsWith("/") ? pathname.slice(1) : pathname,
-		);
-		const relativePath = path.relative(distDirectory, assetPath);
-		if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
-			throw new Error(`Stylesheet escapes dist directory: ${stylesheetUrl}`);
-		}
+			const assetPath = path.resolve(
+				distDirectory,
+				pathname.startsWith("/") ? pathname.slice(1) : pathname,
+			);
+			const relativePath = path.relative(distDirectory, assetPath);
+			if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+				throw new Error(
+					`Stylesheet escapes dist directory: ${stylesheetUrl}`,
+				);
+			}
 
-		return readFile(assetPath, "utf8");
-	}),
-);
-
-const loadedCss = `${inlineStyles}\n${linkedStyles.join("\n")}`;
-const requiredRules = [
-	["--page-bg:", "page background variable"],
-	["--card-bg:", "card background variable"],
-	["--radius-large:", "shared radius variable"],
-	["#banner-carousel", "banner layout styles"],
-	[".widget-container", "responsive widget styles"],
-];
-const missingRules = requiredRules
-	.filter(([token]) => !loadedCss.includes(token))
-	.map(([, description]) => description);
-
-if (missingRules.length > 0) {
-	const loadedStylesheets = stylesheetUrls.join(", ") || "none";
-	throw new Error(
-		`Homepage is missing global styles: ${missingRules.join(", ")}. ` +
-			`Loaded stylesheets: ${loadedStylesheets}`,
+			return readFile(assetPath, "utf8");
+		}),
 	);
+
+	return {
+		html,
+		loadedCss: `${inlineStyles}\n${linkedStyles.join("\n")}`,
+		stylesheetUrls,
+	};
 }
 
-console.log(
-	"Verified homepage global styles across " +
-		`${stylesheetUrls.length} linked stylesheet(s).`,
-);
+const pages = [
+	{
+		name: "Homepage",
+		htmlPath: "index.html",
+		requiredMarkup: [],
+		requiredRules: [
+			["--page-bg:", "page background variable"],
+			["--card-bg:", "card background variable"],
+			["--radius-large:", "shared radius variable"],
+			["#banner-carousel", "banner layout styles"],
+			[".widget-container", "responsive widget styles"],
+		],
+	},
+	{
+		name: "About page",
+		htmlPath: "about/index.html",
+		requiredMarkup: [["card-github", "rendered GitHub repository card"]],
+		requiredRules: [
+			[".card-github", "GitHub repository card styles"],
+			[".custom-md .image-grid", "extended Markdown layout styles"],
+		],
+	},
+];
+
+for (const page of pages) {
+	const { html, loadedCss, stylesheetUrls } = await loadPageStyles(page.htmlPath);
+	const missingMarkup = page.requiredMarkup
+		.filter(([token]) => !html.includes(token))
+		.map(([, description]) => description);
+	const missingRules = page.requiredRules
+		.filter(([token]) => !loadedCss.includes(token))
+		.map(([, description]) => description);
+
+	if (missingMarkup.length > 0 || missingRules.length > 0) {
+		const loadedStylesheets = stylesheetUrls.join(", ") || "none";
+		const missing = [
+			...missingMarkup.map((description) => `${description} markup`),
+			...missingRules,
+		];
+		throw new Error(
+			`${page.name} is missing: ${missing.join(", ")}. ` +
+				`Loaded stylesheets: ${loadedStylesheets}`,
+		);
+	}
+
+	console.log(
+		`Verified ${page.name.toLowerCase()} styles across ` +
+			`${stylesheetUrls.length} linked stylesheet(s).`,
+	);
+}

--- a/src/components/features/auth/Encryptor.astro
+++ b/src/components/features/auth/Encryptor.astro
@@ -1,8 +1,5 @@
 ---
-import "@/styles/markdown.css";
-import "@/styles/expressive-code.css";
 import "@/styles/encrypted-content.css";
-import "@/styles/markdown-extend.styl";
 
 import { encryptContent } from "@utils/crypto-utils";
 

--- a/src/components/misc/Markdown.astro
+++ b/src/components/misc/Markdown.astro
@@ -1,4 +1,6 @@
 ---
+import "@/styles/markdown.css";
+import "@/styles/markdown-extend.styl";
 
 interface Props {
 	class: string;

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -14,6 +14,18 @@ const mainStyles = await readFile(
 	new URL("../src/styles/main.css", import.meta.url),
 	"utf8",
 );
+const markdownSource = await readFile(
+	new URL("../src/components/misc/Markdown.astro", import.meta.url),
+	"utf8",
+);
+const encryptorSource = await readFile(
+	new URL("../src/components/features/auth/Encryptor.astro", import.meta.url),
+	"utf8",
+);
+const globalStyleCheckSource = await readFile(
+	new URL("../scripts/check-global-style-loading.mjs", import.meta.url),
+	"utf8",
+);
 const packageConfig = JSON.parse(
 	await readFile(new URL("../package.json", import.meta.url), "utf8"),
 );
@@ -40,6 +52,31 @@ describe("Global style loading regressions", () => {
 			packageConfig.scripts.build,
 			/node scripts\/check-global-style-loading\.mjs/,
 		);
+	});
+
+	it("loads Markdown styles from the Markdown wrapper", () => {
+		for (const stylesheet of ["markdown.css", "markdown-extend.styl"]) {
+			assert.ok(
+				markdownSource.includes(`import "@/styles/${stylesheet}";`),
+				`${stylesheet} must follow every rendered Markdown surface`,
+			);
+			assert.ok(
+				!encryptorSource.includes(`import "@/styles/${stylesheet}";`),
+				`${stylesheet} must not depend on the optional encryption wrapper`,
+			);
+		}
+
+		assert.ok(
+			encryptorSource.includes('import "@/styles/encrypted-content.css";'),
+			"encrypted content styles must remain owned by the encryption wrapper",
+		);
+		assert.ok(
+			!encryptorSource.includes('import "@/styles/expressive-code.css";'),
+			"global Expressive Code styles must not be duplicated by encryption",
+		);
+		assert.match(globalStyleCheckSource, /about\/index\.html/);
+		assert.match(globalStyleCheckSource, /\.card-github/);
+		assert.match(globalStyleCheckSource, /\.custom-md \.image-grid/);
 	});
 });
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Other (please describe):

## Checklist

- [x] I have read the CONTRIBUTING guidance referenced by the repository template.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

这是 #512 / #513 引入 Markdown 增强能力后暴露出的样式依赖回归，并与 #527 收紧图片 glob、#529 恢复显式全局样式依赖属于同一类问题。本 PR 不关闭现有 Issue。

## Changes

### 问题

About 页已经正确生成 GitHub 卡片 DOM，GitHub API 数据也能加载，但页面没有引用 `markdown.css` 和 `markdown-extend.styl`，因此卡片退化为普通文本，标题锚点等 Markdown 布局样式也会错乱。

根因是基础与扩展 Markdown 样式只由可选的 `Encryptor.astro` 引入。普通文章会因为文章入口静态引用加密组件而偶然获得这些样式，About、Friends 等直接使用 `Markdown.astro` 的独立页面则没有可靠的样式依赖。

### 修复

- 将 `markdown.css` 与 `markdown-extend.styl` 的依赖迁移到 `Markdown.astro`，让样式跟随实际 Markdown 渲染入口。
- `Encryptor.astro` 只保留 `encrypted-content.css`，移除 Markdown 与 Expressive Code 的重复/隐式依赖。
- 将构建产物检查扩展到 `dist/about/index.html`，验证 GitHub 卡片 DOM、`.card-github` 和扩展 Markdown 布局规则实际存在于页面加载的哈希 CSS 中。
- 补充源码回归测试，防止 Markdown 样式再次依赖可选加密包装器。

## How To Test

- `pnpm test`：23 项 Node 回归测试和 8 项加密测试全部通过。
- `pnpm exec biome check scripts/check-global-style-loading.mjs tests/layout-regressions.test.mjs src/components/misc/Markdown.astro src/components/features/auth/Encryptor.astro`：通过。
- `ENABLE_CONTENT_SYNC=false pnpm exec astro check`：检查 320 个文件，0 errors、0 warnings、0 hints。
- `ENABLE_CONTENT_SYNC=false pnpm exec astro build`：成功构建 25 个页面和 54 张响应式图片。
- `node scripts/check-global-style-loading.mjs`：确认首页加载 11 个样式资源，About 页加载 13 个样式资源，并包含 GitHub 卡片与扩展 Markdown 规则。

## Screenshots (if applicable)

<img width="2514" height="1290" alt="image" src="https://github.com/user-attachments/assets/ad32c070-fe4f-4e18-ad3a-25d0c2dba7d1" />

## Additional Notes

- 本 PR 不修改 Markdown AST、GitHub API 请求或 Swup 脚本逻辑。
- Firefly 后续补充的代码组间距问题在 Mizuki 中已有 `margin: 1.5rem 0`，无需额外移植。
- PR 分支基于最新官方 `master`，相对上游只有 1 个提交和 4 个文件。