### PR TITLE
fix(markdown): 修复 Mermaid 全屏交互

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "type-check": "tsc --noEmit",
-    "test": "node --experimental-strip-types --test tests/markdown-enhancements.test.mjs tests/layout-regressions.test.mjs tests/image-loading.test.mjs tests/music-player-loading.test.mjs && node tests/crypto.test.mjs",
+    "test": "node --experimental-strip-types --test tests/markdown-enhancements.test.mjs tests/layout-regressions.test.mjs tests/mermaid-interactions.test.mjs tests/image-loading.test.mjs tests/music-player-loading.test.mjs && node tests/crypto.test.mjs",
     "prepare-images": "node scripts/prepare-default-images.mjs",
     "new-post": "node scripts/new-post.js",
     "format": "biome format --write ./src",

--- a/src/components/features/markdown/MermaidManager.astro
+++ b/src/components/features/markdown/MermaidManager.astro
@@ -1,0 +1,4 @@
+<!-- The shared runtime is bundled once and loads the Mermaid CDN only when needed. -->
+<script>
+	import "@/plugins/mermaid-render-script.js";
+</script>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -76,7 +76,7 @@ declare global {
 		hljs?: {
 			highlightElement: (block: HTMLElement) => void;
 		};
-		renderMermaidDiagrams?: () => void;
+		renderMermaidDiagrams?: () => void | Promise<void>;
 
 		// Sidebar manager window properties
 		__mizukiSidebarResizeHandler?: () => void;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,6 +6,7 @@ import ConfigCarrier from "@components/misc/ConfigCarrier.astro";
 import MusicPlayer from "@components/widgets/music-player/MusicPlayer.svelte";
 import CodeGroupManager from "@/components/features/markdown/CodeGroupManager.astro";
 import DiagramManager from "@/components/features/markdown/DiagramManager.astro";
+import MermaidManager from "@/components/features/markdown/MermaidManager.astro";
 import { pioConfig, profileConfig, siteConfig } from "@/config";
 
 const BANNER_HEIGHT = 35;
@@ -247,6 +248,7 @@ const bannerOffset =
 
 		<CodeGroupManager />
 		<DiagramManager />
+		<MermaidManager />
 
 		<!-- increase the page height during page transition to prevent the scrolling animation from jumping -->
 		<div id="page-height-extend" class="hidden h-[300vh]"></div>

--- a/src/plugins/mermaid-render-script.js
+++ b/src/plugins/mermaid-render-script.js
@@ -1,270 +1,357 @@
 (() => {
-	// 单例模式：检查是否已经初始化过
-	if (window.mermaidInitialized) {
-		// 如果已经初始化过，只确保 renderMermaidDiagrams 函数可用
-		if (typeof window.renderMermaidDiagrams !== "function") {
-			window.renderMermaidDiagrams = renderMermaidDiagrams;
-		}
-		return;
-	}
-
+	if (window.mermaidInitialized) return;
 	window.mermaidInitialized = true;
 
-	// 记录当前主题状态，避免不必要的重新渲染
-	let currentTheme = null;
-	let isRendering = false; // 防止并发渲染
-	let retryCount = 0;
+	const MIN_SCALE = 0.2;
+	const MAX_SCALE = 6;
+	const ZOOM_STEP = 1.2;
 	const MAX_RETRIES = 3;
-	const RETRY_DELAY = 1000; // 1秒
-	let fullscreenOverlay = null;
+	const RETRY_DELAY = 1000;
 
-	function injectFullscreenStyles() {
-		if (document.getElementById("mermaid-fullscreen-style")) {
-			return;
-		}
-
-		const style = document.createElement("style");
-		style.id = "mermaid-fullscreen-style";
-		style.textContent = `
-		:where(.mermaid[data-mermaid-code]) { position: relative; }
-		.mermaid-fullscreen-btn {
-			position: absolute;
-			top: 10px;
-			right: 10px;
-			height: 36px;
-			width: 36px;
-			display: inline-flex;
-			align-items: center;
-			justify-content: center;
-			opacity: 0;
-			transition: opacity 0.2s ease;
-			z-index: 3;
-		}
-		.mermaid:hover .mermaid-fullscreen-btn,
-		.mermaid:focus-within .mermaid-fullscreen-btn {
-			opacity: 1;
-		}
-		.mermaid-fullscreen-overlay {
-			position: fixed;
-			inset: 0;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			padding: clamp(12px, 3vw, 28px);
-			backdrop-filter: blur(6px);
-			z-index: 9999;
-			background: var(--mermaid-fs-backdrop, rgba(15, 23, 42, 0.9));
-		}
-		.mermaid-fullscreen-stage {
-			position: relative;
-			width: min(1200px, 96vw);
-			max-height: 90vh;
-			padding: clamp(12px, 2vw, 18px);
-			background: var(--mermaid-fs-surface, #0f172a);
-			border: 1px solid var(--mermaid-fs-border, rgba(255,255,255,0.08));
-			border-radius: 16px;
-			box-shadow: 0 20px 80px rgba(0, 0, 0, 0.35);
-			overflow: hidden;
-		}
-		.mermaid-fullscreen-stage svg {
-			width: 100%;
-			height: auto;
-			min-height: 320px;
-		}
-		.mermaid-fullscreen-close {
-			position: absolute;
-			top: 10px;
-			right: 10px;
-			z-index: 4;
-		}
-		.mermaid-fullscreen-overlay .mermaid-zoom-controls {
-			position: absolute;
-			left: 12px;
-			bottom: 12px;
-			display: flex;
-			gap: 8px;
-		}
-		body.mermaid-fullscreen-open { overflow: hidden; }
-		`;
-		document.head.appendChild(style);
-	}
+	let currentTheme = null;
+	let fullscreenSession = null;
+	let isRendering = false;
+	let mermaidLoadPromise = null;
+	let renderQueued = false;
+	let renderTimer = null;
+	let retryCount = 0;
+	let themeObserver = null;
+	const diagramControllers = new WeakMap();
 
 	function getThemePalette() {
-		const htmlElement = document.documentElement;
-		const isDark = htmlElement.classList.contains("dark");
-		const styles = getComputedStyle(htmlElement);
-		const primary =
-			styles.getPropertyValue("--primary")?.trim() ||
-			(isDark ? "#7dd3fc" : "#2563eb");
+		const root = document.documentElement;
+		const isDark = root.classList.contains("dark");
+		const styles = getComputedStyle(root);
 		const surface =
-			styles.getPropertyValue("--card-bg")?.trim() ||
-			styles.getPropertyValue("--surface")?.trim() ||
+			styles.getPropertyValue("--card-bg").trim() ||
+			styles.getPropertyValue("--surface").trim() ||
 			(isDark ? "#0b1220" : "#ffffff");
-		const text =
-			styles.getPropertyValue("--text-color")?.trim() ||
-			styles.getPropertyValue("--foreground")?.trim() ||
-			(isDark ? "#e5e7eb" : "#0f172a");
-		const muted =
-			styles.getPropertyValue("--muted")?.trim() ||
-			styles.getPropertyValue("--muted-foreground")?.trim() ||
-			(isDark ? "#1f2937" : "#e5e7eb");
 		const backdrop = isDark
 			? "rgba(8, 15, 30, 0.9)"
 			: "rgba(255, 255, 255, 0.94)";
+		const border = isDark
+			? "rgba(255, 255, 255, 0.08)"
+			: "rgba(15, 23, 42, 0.08)";
 
-		return { isDark, primary, surface, text, muted, backdrop };
+		return { surface, backdrop, border };
+	}
+
+	function createControlButton(action, signal) {
+		const button = document.createElement("button");
+		button.type = "button";
+		button.className = "mermaid-control";
+		button.dataset.action = action.name;
+		button.textContent = action.label;
+		button.title = action.title;
+		button.setAttribute("aria-label", action.title);
+		button.addEventListener(
+			"click",
+			(event) => {
+				event.preventDefault();
+				event.stopPropagation();
+				action.run();
+			},
+			{ signal },
+		);
+		return button;
+	}
+
+	function disposeDiagramInteraction(host) {
+		diagramControllers.get(host)?.destroy();
+	}
+
+	function attachDiagramInteraction(host, svgElement, options = {}) {
+		disposeDiagramInteraction(host);
+
+		const eventController = new AbortController();
+		const { signal } = eventController;
+		const viewport = document.createElement("div");
+		viewport.className = "mermaid-viewport";
+		const wrapper = document.createElement("div");
+		wrapper.className = "mermaid-zoom-wrapper";
+		wrapper.appendChild(svgElement);
+		viewport.appendChild(wrapper);
+
+		const controls = document.createElement("div");
+		controls.className = "mermaid-zoom-controls";
+		controls.setAttribute("role", "toolbar");
+		controls.setAttribute("aria-label", "Mermaid diagram controls");
+
+		const state = { scale: 1, x: 0, y: 0 };
+		let isPanning = false;
+		let startClientX = 0;
+		let startClientY = 0;
+		let startX = 0;
+		let startY = 0;
+
+		function applyTransform() {
+			wrapper.style.transform = `translate3d(${state.x}px, ${state.y}px, 0) scale(${state.scale})`;
+		}
+
+		function setScale(nextScale, clientPoint) {
+			const scale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, nextScale));
+			if (scale === state.scale) return;
+
+			const rect = viewport.getBoundingClientRect();
+			const anchorX = clientPoint
+				? clientPoint.clientX - rect.left
+				: rect.width / 2;
+			const anchorY = clientPoint
+				? clientPoint.clientY - rect.top
+				: rect.height / 2;
+			const diagramX = (anchorX - state.x) / state.scale;
+			const diagramY = (anchorY - state.y) / state.scale;
+
+			state.scale = +scale.toFixed(3);
+			state.x = anchorX - diagramX * state.scale;
+			state.y = anchorY - diagramY * state.scale;
+			applyTransform();
+		}
+
+		function resetView() {
+			state.scale = 1;
+			state.x = 0;
+			state.y = 0;
+			applyTransform();
+		}
+
+		const actions = [
+			{
+				name: "zoom-in",
+				label: "+",
+				title: "Zoom in",
+				run: () => setScale(state.scale * ZOOM_STEP),
+			},
+			{
+				name: "zoom-out",
+				label: "−",
+				title: "Zoom out",
+				run: () => setScale(state.scale / ZOOM_STEP),
+			},
+			{
+				name: "reset",
+				label: "⤾",
+				title: "Reset view",
+				run: resetView,
+			},
+		];
+
+		if (typeof options.onFullscreen === "function") {
+			actions.push({
+				name: "fullscreen",
+				label: "⛶",
+				title: "View fullscreen",
+				run: options.onFullscreen,
+			});
+		}
+
+		for (const action of actions) {
+			controls.appendChild(createControlButton(action, signal));
+		}
+		host.replaceChildren(viewport, controls);
+
+		viewport.addEventListener(
+			"pointerdown",
+			(event) => {
+				if (!event.isPrimary) return;
+				if (event.pointerType === "mouse" && event.button !== 0) return;
+
+				event.preventDefault();
+				isPanning = true;
+				startClientX = event.clientX;
+				startClientY = event.clientY;
+				startX = state.x;
+				startY = state.y;
+				viewport.classList.add("is-panning");
+				viewport.setPointerCapture(event.pointerId);
+			},
+			{ signal },
+		);
+
+		viewport.addEventListener(
+			"pointermove",
+			(event) => {
+				if (!isPanning) return;
+				state.x = startX + event.clientX - startClientX;
+				state.y = startY + event.clientY - startClientY;
+				applyTransform();
+			},
+			{ signal },
+		);
+
+		function endPan(event) {
+			if (!isPanning) return;
+			isPanning = false;
+			viewport.classList.remove("is-panning");
+			if (event && viewport.hasPointerCapture(event.pointerId)) {
+				viewport.releasePointerCapture(event.pointerId);
+			}
+		}
+
+		viewport.addEventListener("pointerup", endPan, { signal });
+		viewport.addEventListener("pointercancel", endPan, { signal });
+		viewport.addEventListener(
+			"lostpointercapture",
+			() => {
+				isPanning = false;
+				viewport.classList.remove("is-panning");
+			},
+			{ signal },
+		);
+
+		viewport.addEventListener(
+			"wheel",
+			(event) => {
+				event.preventDefault();
+				const factor = event.deltaY < 0 ? 1.12 : 1 / 1.12;
+				setScale(state.scale * factor, event);
+			},
+			{ passive: false, signal },
+		);
+
+		viewport.addEventListener("dblclick", resetView, { signal });
+		applyTransform();
+
+		const controller = {
+			destroy() {
+				eventController.abort();
+				diagramControllers.delete(host);
+			},
+		};
+		diagramControllers.set(host, controller);
+		return controller;
 	}
 
 	function closeFullscreen() {
-		if (fullscreenOverlay) {
-			fullscreenOverlay.remove();
-			fullscreenOverlay = null;
-			document.body.classList.remove("mermaid-fullscreen-open");
+		if (!fullscreenSession) return;
+
+		const session = fullscreenSession;
+		fullscreenSession = null;
+		session.eventController.abort();
+		session.diagramController.destroy();
+		session.overlay.remove();
+		document.body.classList.remove("mermaid-fullscreen-open");
+
+		if (session.previousFocus?.isConnected) {
+			session.previousFocus.focus({ preventScroll: true });
 		}
 	}
 
 	function openFullscreen(svgElement) {
-		const palette = getThemePalette();
-		injectFullscreenStyles();
-
 		closeFullscreen();
 
+		const palette = getThemePalette();
+		const previousFocus =
+			document.activeElement instanceof HTMLElement
+				? document.activeElement
+				: null;
+		const eventController = new AbortController();
+		const { signal } = eventController;
 		const overlay = document.createElement("div");
 		overlay.className = "mermaid-fullscreen-overlay";
+		overlay.setAttribute("role", "dialog");
+		overlay.setAttribute("aria-modal", "true");
+		overlay.setAttribute("aria-label", "Fullscreen Mermaid diagram");
 		overlay.style.setProperty("--mermaid-fs-backdrop", palette.backdrop);
 		overlay.style.setProperty("--mermaid-fs-surface", palette.surface);
-		overlay.style.setProperty(
-			"--mermaid-fs-border",
-			palette.isDark ? "rgba(255,255,255,0.08)" : "rgba(15,23,42,0.08)",
-		);
-
-		const closeButton = document.createElement("button");
-		closeButton.className =
-			"mermaid-fullscreen-close btn-regular rounded-lg h-10 w-10";
-		closeButton.title = "关闭全屏";
-		closeButton.textContent = "✕";
-		closeButton.addEventListener("click", closeFullscreen);
+		overlay.style.setProperty("--mermaid-fs-border", palette.border);
 
 		const stage = document.createElement("div");
 		stage.className = "mermaid-fullscreen-stage";
-
 		const clonedSvg = svgElement.cloneNode(true);
-		stage.appendChild(clonedSvg);
+		clonedSvg.removeAttribute("width");
+		clonedSvg.removeAttribute("height");
+		clonedSvg.style.width = "100%";
+		clonedSvg.style.height = "100%";
+		clonedSvg.style.maxWidth = "100%";
+		clonedSvg.style.maxHeight = "100%";
+		clonedSvg.style.minHeight = "0";
+
+		const diagramController = attachDiagramInteraction(stage, clonedSvg);
+		const closeButton = document.createElement("button");
+		closeButton.type = "button";
+		closeButton.className = "mermaid-fullscreen-close";
+		closeButton.textContent = "×";
+		closeButton.title = "Close fullscreen";
+		closeButton.setAttribute("aria-label", "Close fullscreen diagram");
+		closeButton.addEventListener("click", closeFullscreen, { signal });
+		stage.appendChild(closeButton);
 		overlay.appendChild(stage);
-		overlay.appendChild(closeButton);
 
-		overlay.addEventListener("click", (ev) => {
-			if (ev.target === overlay) {
-				closeFullscreen();
-			}
-		});
+		overlay.addEventListener(
+			"click",
+			(event) => {
+				if (event.target === overlay) closeFullscreen();
+			},
+			{ signal },
+		);
 
-		const escHandler = (ev) => {
-			if (ev.key === "Escape") {
-				closeFullscreen();
-			}
+		document.addEventListener(
+			"keydown",
+			(event) => {
+				if (event.key === "Escape") {
+					event.preventDefault();
+					closeFullscreen();
+					return;
+				}
+				if (event.key !== "Tab") return;
+
+				const focusable = Array.from(
+					overlay.querySelectorAll("button:not([disabled])"),
+				);
+				if (focusable.length === 0) return;
+				const first = focusable[0];
+				const last = focusable[focusable.length - 1];
+				if (event.shiftKey && document.activeElement === first) {
+					event.preventDefault();
+					last.focus();
+				} else if (!event.shiftKey && document.activeElement === last) {
+					event.preventDefault();
+					first.focus();
+				}
+			},
+			{ signal },
+		);
+
+		fullscreenSession = {
+			overlay,
+			eventController,
+			diagramController,
+			previousFocus,
 		};
-		window.addEventListener("keydown", escHandler, { once: true });
-
 		document.body.appendChild(overlay);
 		document.body.classList.add("mermaid-fullscreen-open");
-		fullscreenOverlay = overlay;
-
-		// 为全屏内的图表添加缩放控制
-		attachZoomControls(stage, clonedSvg);
+		closeButton.focus({ preventScroll: true });
 	}
 
-	function ensureFullscreenButton(element) {
-		if (element.querySelector(".mermaid-fullscreen-btn")) {
-			return;
-		}
-		const btn = document.createElement("button");
-		btn.type = "button";
-		btn.className = "mermaid-fullscreen-btn btn-regular rounded-lg h-9 w-9";
-		btn.title = "全屏查看";
-		btn.setAttribute("aria-label", "全屏查看 Mermaid 图表");
-		btn.innerHTML = "⛶";
-		btn.addEventListener("click", (ev) => {
-			ev.stopPropagation();
-			const svg = element.querySelector("svg");
-			if (!svg) {
-				return;
-			}
-			openFullscreen(svg);
-		});
-		element.appendChild(btn);
-	}
-
-	// 检查主题是否真的发生了变化
 	function hasThemeChanged() {
-		const isDark = document.documentElement.classList.contains("dark");
-		const newTheme = isDark ? "dark" : "default";
-
-		if (currentTheme !== newTheme) {
-			currentTheme = newTheme;
-			return true;
-		}
-		return false;
+		const nextTheme = document.documentElement.classList.contains("dark")
+			? "dark"
+			: "default";
+		if (currentTheme === nextTheme) return false;
+		currentTheme = nextTheme;
+		return true;
 	}
 
-	// 等待 Mermaid 库加载完成
-	function waitForMermaid(timeout = 10000) {
-		return new Promise((resolve, reject) => {
-			const startTime = Date.now();
-
-			function check() {
-				if (window.mermaid && typeof window.mermaid.initialize === "function") {
-					resolve(window.mermaid);
-				} else if (Date.now() - startTime > timeout) {
-					reject(new Error("Mermaid library failed to load within timeout"));
-				} else {
-					setTimeout(check, 100);
-				}
-			}
-
-			check();
-		});
-	}
-
-	// 存储 MutationObserver 实例
-	let themeObserver = null;
-
-	// 清理 MutationObserver
 	function cleanupMutationObserver() {
-		if (themeObserver) {
-			themeObserver.disconnect();
-			themeObserver = null;
-		}
+		themeObserver?.disconnect();
+		themeObserver = null;
 	}
 
-	// 设置 MutationObserver 监听 html 元素的 class 属性变化
 	function setupMutationObserver() {
 		cleanupMutationObserver();
-
 		themeObserver = new MutationObserver((mutations) => {
-			mutations.forEach((mutation) => {
-				if (
-					mutation.type === "attributes" &&
-					mutation.attributeName === "class"
-				) {
-					// 检查是否是 dark 类的变化
-					const target = mutation.target;
-					const wasDark = mutation.oldValue
-						? mutation.oldValue.includes("dark")
-						: false;
-					const isDark = target.classList.contains("dark");
-
-					if (wasDark !== isDark) {
-						if (hasThemeChanged()) {
-							// 延迟渲染，避免主题切换时的闪烁
-							setTimeout(() => renderMermaidDiagrams(), 150);
-						}
-					}
+			for (const mutation of mutations) {
+				const wasDark =
+					mutation.oldValue?.split(/\s+/).includes("dark") ?? false;
+				const isDark = document.documentElement.classList.contains("dark");
+				if (wasDark !== isDark && hasThemeChanged()) {
+					closeFullscreen();
+					scheduleRender(150);
+					break;
 				}
-			});
+			}
 		});
-
-		// 开始观察 html 元素的 class 属性变化
 		themeObserver.observe(document.documentElement, {
 			attributes: true,
 			attributeFilter: ["class"],
@@ -272,355 +359,128 @@
 		});
 	}
 
-	// 缩放平移
-	function attachZoomControls(element, svgElement) {
-		if (element.__zoomAttached) {
-			return;
-		}
-		element.__zoomAttached = true;
-
-		const wrapper = document.createElement("div");
-		wrapper.className = "mermaid-zoom-wrapper";
-
-		const svgParent = svgElement.parentNode;
-		wrapper.appendChild(svgElement);
-		svgParent.appendChild(wrapper);
-
-		let scale = 1;
-		let tx = 0;
-		let ty = 0;
-		const MIN_SCALE = 0.2;
-		const MAX_SCALE = 6;
-
-		function applyTransform() {
-			wrapper.style.transform = `translate(${tx}px, ${ty}px) scale(${scale})`;
-		}
-		const controls = document.createElement("div");
-		controls.className = "mermaid-zoom-controls";
-		controls.innerHTML = `
-			<button class="btn-regular rounded-lg h-10 w-10 active:scale-90" data-action="zoom-in" title="Zoom in">+</button>
-			<button class="btn-regular rounded-lg h-10 w-10 active:scale-90" data-action="zoom-out" title="Zoom out">−</button>
-			<button class="btn-regular rounded-lg h-10 w-10 active:scale-90" data-action="reset" title="Reset">⤾</button>
-		`;
-		element.appendChild(controls);
-
-		controls.addEventListener("click", (ev) => {
-			const action = ev.target.getAttribute?.("data-action");
-			if (!action) {
-				return;
-			}
-
-			switch (action) {
-				case "zoom-in":
-					scale = Math.min(MAX_SCALE, +(scale * 1.2).toFixed(3));
-					applyTransform();
-					break;
-				case "zoom-out":
-					scale = Math.max(MIN_SCALE, +(scale / 1.2).toFixed(3));
-					applyTransform();
-					break;
-				case "reset":
-					scale = 1;
-					tx = 0;
-					ty = 0;
-					applyTransform();
-					break;
-			}
-		});
-
-		let isPanning = false;
-		let startX = 0;
-		let startY = 0;
-		let startTx = 0;
-		let startTy = 0;
-
-		wrapper.style.touchAction = "none";
-
-		wrapper.addEventListener("pointerdown", (ev) => {
-			if (ev.button !== 0) {
-				return;
-			} // 仅左键
-			isPanning = true;
-			wrapper.setPointerCapture(ev.pointerId);
-			startX = ev.clientX;
-			startY = ev.clientY;
-			startTx = tx;
-			startTy = ty;
-		});
-
-		wrapper.addEventListener("pointermove", (ev) => {
-			if (!isPanning) {
-				return;
-			}
-			const dx = ev.clientX - startX;
-			const dy = ev.clientY - startY;
-			tx = startTx + dx / scale; // 根据当前缩放调整灵敏度
-			ty = startTy + dy / scale;
-			applyTransform();
-		});
-
-		wrapper.addEventListener("pointerup", (ev) => {
-			isPanning = false;
-			try {
-				wrapper.releasePointerCapture(ev.pointerId);
-			} catch (_e) {}
-		});
-
-		wrapper.addEventListener("pointercancel", () => {
-			isPanning = false;
-		});
-
-		// 鼠标滚轮缩放
-		element.addEventListener(
-			"wheel",
-			(ev) => {
-				ev.preventDefault();
-				const delta = -ev.deltaY;
-				const zoomFactor = delta > 0 ? 1.12 : 1 / 1.12;
-				const prevScale = scale;
-				scale = Math.min(
-					MAX_SCALE,
-					Math.max(MIN_SCALE, +(scale * zoomFactor).toFixed(3)),
-				);
-
-				const rect = wrapper.getBoundingClientRect();
-				const cx = ev.clientX - rect.left;
-				const cy = ev.clientY - rect.top;
-
-				const worldX = cx / prevScale - tx;
-				const worldY = cy / prevScale - ty;
-
-				tx = cx / scale - worldX;
-				ty = cy / scale - worldY;
-
-				applyTransform();
-			},
-			{ passive: false },
-		);
-
-		// 双击重置
-		wrapper.addEventListener("dblclick", () => {
-			scale = 1;
-			tx = 0;
-			ty = 0;
-			applyTransform();
-		});
-		applyTransform();
-		let resizeTimer = null;
-		window.addEventListener("resize", () => {
-			clearTimeout(resizeTimer);
-			resizeTimer = setTimeout(() => {
-				applyTransform();
-			}, 200);
-		});
-	}
-
-	// 设置其他事件监听器
-	function setupEventListeners() {
-		// 监听页面切换
-		document.addEventListener("astro:page-load", () => {
-			// 重新初始化主题状态
-			currentTheme = null;
-			retryCount = 0; // 重置重试计数
-			if (hasThemeChanged()) {
-				setTimeout(() => renderMermaidDiagrams(), 100);
-			}
-		});
-
-		// 监听页面可见性变化，页面重新可见时重新渲染
-		document.addEventListener("visibilitychange", () => {
-			if (!document.hidden) {
-				setTimeout(() => renderMermaidDiagrams(), 200);
-			}
-		});
-
-		// 页面切换前清理
-		document.addEventListener("astro:before-swap", cleanupMutationObserver);
-
-		// 页面切换前清理全屏状态
-		document.addEventListener("astro:before-swap", closeFullscreen);
-
-		// Swup 页面切换时重新设置 Observer
-		document.addEventListener("astro:after-swap", () => {
-			if (themeObserver === null) {
-				setupMutationObserver();
-			}
-		});
-	}
-
-	async function initializeMermaid() {
-		try {
-			await waitForMermaid();
-
-			// 初始化 Mermaid 配置
-			window.mermaid.initialize({
-				startOnLoad: false,
-				theme: "default",
-				themeVariables: {
-					fontFamily: "inherit",
-					fontSize: "16px",
-				},
-				securityLevel: "loose",
-				// 添加错误处理配置
-				errorLevel: "warn",
-				logLevel: "error",
+	async function loadMermaid() {
+		if (window.mermaid?.render) return;
+		if (!mermaidLoadPromise) {
+			mermaidLoadPromise = new Promise((resolve, reject) => {
+				const primaryScript = document.createElement("script");
+				primaryScript.src =
+					"https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js";
+				primaryScript.onload = resolve;
+				primaryScript.onerror = () => {
+					primaryScript.remove();
+					const fallbackScript = document.createElement("script");
+					fallbackScript.src =
+						"https://unpkg.com/mermaid@11/dist/mermaid.min.js";
+					fallbackScript.onload = resolve;
+					fallbackScript.onerror = () => {
+						fallbackScript.remove();
+						reject(
+							new Error(
+								"Failed to load Mermaid from both primary and fallback CDNs",
+							),
+						);
+					};
+					document.head.appendChild(fallbackScript);
+				};
+				document.head.appendChild(primaryScript);
 			});
-
-			// 渲染所有 Mermaid 图表
-			await renderMermaidDiagrams();
-		} catch (error) {
-			console.error("Failed to initialize Mermaid:", error);
-			// 如果初始化失败，尝试重新加载
-			if (retryCount < MAX_RETRIES) {
-				retryCount++;
-				setTimeout(() => initializeMermaid(), RETRY_DELAY * retryCount);
-			}
 		}
+
+		try {
+			await mermaidLoadPromise;
+		} catch (error) {
+			mermaidLoadPromise = null;
+			throw error;
+		}
+	}
+
+	function configureMermaid(isDark) {
+		window.mermaid.initialize({
+			startOnLoad: false,
+			theme: isDark ? "dark" : "default",
+			themeVariables: {
+				fontFamily: "inherit",
+				fontSize: "16px",
+				primaryColor: isDark ? "#ffffff" : "#000000",
+				primaryTextColor: isDark ? "#ffffff" : "#000000",
+				primaryBorderColor: isDark ? "#ffffff" : "#000000",
+				lineColor: isDark ? "#ffffff" : "#000000",
+				secondaryColor: isDark ? "#333333" : "#f0f0f0",
+				tertiaryColor: isDark ? "#555555" : "#e0e0e0",
+			},
+			securityLevel: "loose",
+			errorLevel: "warn",
+			logLevel: "error",
+		});
 	}
 
 	async function renderMermaidDiagrams() {
-		// 防止并发渲染
 		if (isRendering) {
+			renderQueued = true;
 			return;
 		}
 
-		// 检查 Mermaid 是否可用
-		if (!window.mermaid || typeof window.mermaid.render !== "function") {
-			console.warn("Mermaid not available, skipping render");
-			return;
-		}
+		const mermaidElements = Array.from(
+			document.querySelectorAll(".mermaid[data-mermaid-code]"),
+		);
+		if (mermaidElements.length === 0) return;
 
 		isRendering = true;
 		window.dispatchEvent(new CustomEvent("mermaid:render:start"));
 
 		try {
-			const mermaidElements = Array.from(
-				document.querySelectorAll(".mermaid[data-mermaid-code]"),
-			);
+			const isDark = document.documentElement.classList.contains("dark");
+			configureMermaid(isDark);
+			const batchSize = 3;
 
-			if (mermaidElements.length === 0) {
-				isRendering = false;
-				window.dispatchEvent(
-					new CustomEvent("mermaid:render:done", {
-						detail: { count: 0 },
-					}),
-				);
-				return;
-			}
-
-			// 延迟检测主题，确保 DOM 已经更新
-			await new Promise((resolve) => setTimeout(resolve, 100));
-
-			const htmlElement = document.documentElement;
-			const isDark = htmlElement.classList.contains("dark");
-			const theme = isDark ? "dark" : "default";
-
-			// 更新 Mermaid 主题（只需要更新一次）
-			window.mermaid.initialize({
-				startOnLoad: false,
-				theme: theme,
-				themeVariables: {
-					fontFamily: "inherit",
-					fontSize: "16px",
-					// 强制应用主题变量
-					primaryColor: isDark ? "#ffffff" : "#000000",
-					primaryTextColor: isDark ? "#ffffff" : "#000000",
-					primaryBorderColor: isDark ? "#ffffff" : "#000000",
-					lineColor: isDark ? "#ffffff" : "#000000",
-					secondaryColor: isDark ? "#333333" : "#f0f0f0",
-					tertiaryColor: isDark ? "#555555" : "#e0e0e0",
-				},
-				securityLevel: "loose",
-				errorLevel: "warn",
-				logLevel: "error",
-			});
-
-			// 分批渲染，避免一次性阻塞主线程
-			const BATCH_SIZE = 3;
-			let index = 0;
-
-			async function renderBatch() {
-				const batch = mermaidElements.slice(index, index + BATCH_SIZE);
-				if (batch.length === 0) {
-					return;
-				}
-
+			for (let index = 0; index < mermaidElements.length; index += batchSize) {
+				const batch = mermaidElements.slice(index, index + batchSize);
 				await Promise.all(
 					batch.map(async (element, localIndex) => {
-						const globalIndex = index + localIndex;
+						const code = element.getAttribute("data-mermaid-code");
+						if (!code) return;
+
+						disposeDiagramInteraction(element);
 						let attempts = 0;
-						const maxAttempts = 3;
-
-						while (attempts < maxAttempts) {
+						while (attempts < 3) {
 							try {
-								const code = element.getAttribute("data-mermaid-code");
-
-								if (!code) {
-									break;
-								}
-
-								// 显示加载状态
 								element.innerHTML =
 									'<div class="mermaid-loading">Rendering diagram...</div>';
+								const renderId = `mermaid-${Date.now()}-${index + localIndex}-${attempts}`;
+								const { svg } = await window.mermaid.render(renderId, code);
+								if (!element.isConnected) return;
 
-								// 渲染图表
-								const { svg } = await window.mermaid.render(
-									`mermaid-${Date.now()}-${globalIndex}-${attempts}`,
-									code,
+								const doc = new DOMParser().parseFromString(
+									svg,
+									"image/svg+xml",
 								);
-
-								const parser = new DOMParser();
-								const doc = parser.parseFromString(svg, "image/svg+xml");
 								const svgElement = doc.documentElement;
-
-								element.innerHTML = "";
-								element.__zoomAttached = false;
-								element.appendChild(svgElement);
-
-								// 添加响应式支持
-								const insertedSvg = element.querySelector("svg");
-								if (insertedSvg) {
-									insertedSvg.setAttribute("width", "100%");
-									insertedSvg.removeAttribute("height");
-									insertedSvg.style.maxWidth = "100%";
-									insertedSvg.style.height = "auto";
-									//Todo 需要根据实际情况
-									insertedSvg.style.minHeight = "300px";
-
-									// 强制应用样式
-									if (isDark) {
-										svgElement.style.filter = "brightness(0.9) contrast(1.1)";
-									} else {
-										svgElement.style.filter = "none";
-									}
-									attachZoomControls(element, insertedSvg);
-									ensureFullscreenButton(element);
-								}
-
-								// 渲染成功，跳出重试循环
-								break;
+								svgElement.setAttribute("width", "100%");
+								svgElement.removeAttribute("height");
+								svgElement.style.maxWidth = "100%";
+								svgElement.style.height = "auto";
+								svgElement.style.filter = isDark
+									? "brightness(0.9) contrast(1.1)"
+									: "none";
+								attachDiagramInteraction(element, svgElement, {
+									onFullscreen: () => openFullscreen(svgElement),
+								});
+								return;
 							} catch (error) {
-								attempts++;
+								attempts += 1;
 								console.warn(
-									`Mermaid rendering attempt ${attempts} failed for element ${globalIndex}:`,
+									`Mermaid rendering attempt ${attempts} failed for element ${index + localIndex}:`,
 									error,
 								);
-
-								if (attempts >= maxAttempts) {
-									console.error(
-										`Failed to render Mermaid diagram after ${maxAttempts} attempts:`,
-										error,
-									);
+								if (attempts >= 3) {
 									element.innerHTML = `
 										<div class="mermaid-error">
-											<p>Failed to render diagram after ${maxAttempts} attempts.</p>
-											<button onclick="location.reload()" style="margin-top: 8px; padding: 4px 8px; background: var(--primary); color: white; border: none; border-radius: 4px; cursor: pointer;">
-												Retry Page
-											</button>
+											<p>Failed to render diagram after 3 attempts.</p>
+											<button type="button" onclick="location.reload()">Retry Page</button>
 										</div>
 									`;
 								} else {
-									// 等待一段时间后重试
 									await new Promise((resolve) =>
 										setTimeout(resolve, 500 * attempts),
 									);
@@ -630,114 +490,89 @@
 					}),
 				);
 
-				index += BATCH_SIZE;
-
-				if (index < mermaidElements.length) {
-					// 在空闲时间继续渲染下一批，避免长时间阻塞主线程
+				if (index + batchSize < mermaidElements.length) {
 					await new Promise((resolve) => {
 						if ("requestIdleCallback" in window) {
-							window.requestIdleCallback(() => resolve());
+							window.requestIdleCallback(resolve);
 						} else {
 							setTimeout(resolve, 50);
 						}
 					});
-					return renderBatch();
 				}
 			}
 
-			await renderBatch();
-			retryCount = 0; // 重置重试计数
+			retryCount = 0;
 			window.dispatchEvent(
 				new CustomEvent("mermaid:render:done", {
 					detail: { count: mermaidElements.length },
 				}),
 			);
 		} catch (error) {
-			console.error("Error in renderMermaidDiagrams:", error);
+			console.error("Error rendering Mermaid diagrams:", error);
 			window.dispatchEvent(new CustomEvent("mermaid:render:done"));
-
-			// 如果渲染失败，尝试重新渲染
 			if (retryCount < MAX_RETRIES) {
-				retryCount++;
-				setTimeout(() => renderMermaidDiagrams(), RETRY_DELAY * retryCount);
+				retryCount += 1;
+				scheduleRender(RETRY_DELAY * retryCount);
 			}
 		} finally {
 			isRendering = false;
+			if (renderQueued) {
+				renderQueued = false;
+				scheduleRender();
+			}
 		}
 	}
 
-	// 初始化主题状态
-	function initializeThemeState() {
-		const isDark = document.documentElement.classList.contains("dark");
-		currentTheme = isDark ? "dark" : "default";
+	async function ensureMermaidRendered() {
+		if (!document.querySelector(".mermaid[data-mermaid-code]")) return;
+		try {
+			await loadMermaid();
+			await renderMermaidDiagrams();
+		} catch (error) {
+			console.error("Failed to initialize Mermaid:", error);
+			if (retryCount < MAX_RETRIES) {
+				retryCount += 1;
+				scheduleRender(RETRY_DELAY * retryCount);
+			}
+		}
 	}
 
-	// 加载 Mermaid 库
-	async function loadMermaid() {
-		if (typeof window.mermaid !== "undefined") {
-			return Promise.resolve();
-		}
+	function scheduleRender(delay = 0) {
+		clearTimeout(renderTimer);
+		renderTimer = setTimeout(ensureMermaidRendered, delay);
+	}
 
-		return new Promise((resolve, reject) => {
-			const script = document.createElement("script");
-			script.src =
-				"https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js";
-
-			script.onload = () => {
-				console.log("Mermaid library loaded successfully");
-				resolve();
-			};
-
-			script.onerror = (error) => {
-				console.error("Failed to load Mermaid library:", error);
-				// 尝试备用 CDN
-				const fallbackScript = document.createElement("script");
-				fallbackScript.src = "https://unpkg.com/mermaid@11/dist/mermaid.min.js";
-
-				fallbackScript.onload = () => {
-					console.log("Mermaid library loaded from fallback CDN");
-					resolve();
-				};
-
-				fallbackScript.onerror = () => {
-					reject(
-						new Error(
-							"Failed to load Mermaid from both primary and fallback CDNs",
-						),
-					);
-				};
-
-				document.head.appendChild(fallbackScript);
-			};
-
-			document.head.appendChild(script);
+	function setupEventListeners() {
+		document.addEventListener("astro:page-load", () => {
+			currentTheme = null;
+			retryCount = 0;
+			hasThemeChanged();
+			scheduleRender(100);
+		});
+		document.addEventListener("astro:before-swap", () => {
+			clearTimeout(renderTimer);
+			closeFullscreen();
+			cleanupMutationObserver();
+		});
+		document.addEventListener("astro:after-swap", () => {
+			setupMutationObserver();
+			scheduleRender();
+		});
+		document.addEventListener("visibilitychange", () => {
+			if (!document.hidden) scheduleRender(200);
 		});
 	}
 
-	// 主初始化函数
-	async function initialize() {
-		try {
-			// 设置监听器
-			setupMutationObserver();
-			setupEventListeners();
-
-			// 初始化主题状态
-			initializeThemeState();
-
-			// 加载并初始化 Mermaid
-			await loadMermaid();
-			await initializeMermaid();
-
-			// 将 renderMermaidDiagrams 暴露到全局作用域，以便在解密后调用
-			window.renderMermaidDiagrams = renderMermaidDiagrams;
-		} catch (error) {
-			console.error("Failed to initialize Mermaid system:", error);
-		}
+	function initialize() {
+		setupMutationObserver();
+		setupEventListeners();
+		hasThemeChanged();
+		window.renderMermaidDiagrams = ensureMermaidRendered;
+		scheduleRender();
 	}
 
-	// 启动初始化
 	if (document.readyState === "loading") {
-		document.addEventListener("DOMContentLoaded", initialize);
+		document.addEventListener("DOMContentLoaded", initialize, { once: true });
 	} else {
 		initialize();
 	}

--- a/src/plugins/rehype-mermaid.mjs
+++ b/src/plugins/rehype-mermaid.mjs
@@ -1,8 +1,6 @@
 import { h } from "hastscript";
 import { visit } from "unist-util-visit";
 
-import mermaidRenderScript from "./mermaid-render-script.js?raw";
-
 export function rehypeMermaid() {
 	return (tree) => {
 		visit(tree, "element", (node) => {
@@ -34,19 +32,10 @@ export function rehypeMermaid() {
 					],
 				);
 
-				// 创建客户端渲染脚本
-				const renderScript = h(
-					"script",
-					{
-						type: "text/javascript",
-					},
-					mermaidRenderScript,
-				);
-
 				// 替换原始节点
 				node.tagName = "div";
 				node.properties = { class: "mermaid-diagram-container" };
-				node.children = [mermaidContainer, renderScript];
+				node.children = [mermaidContainer];
 			}
 		});
 	};

--- a/src/styles/expressive-code.css
+++ b/src/styles/expressive-code.css
@@ -3,17 +3,6 @@
 .expressive-code {
   @apply relative;
 
-  /* Mermaid 全屏按钮与按钮体系的配色保持一致 */
-  .mermaid-fullscreen-btn {
-    background: var(--btn-regular-bg);
-    color: var(--btn-content);
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.08);
-  }
-
-  .mermaid-fullscreen-btn:hover {
-    background: var(--btn-regular-bg-hover);
-  }
-
   .frame {
     @apply !shadow-none;
   }

--- a/src/styles/markdown-extend.styl
+++ b/src/styles/markdown-extend.styl
@@ -260,20 +260,17 @@ a.card-github.fetch-error
   text-align: center
 
 .mermaid
-  display: flex
-  justify-content: center
-  align-items: center
   min-height: 100px
   font-family: inherit
-  position: relative;
-  overflow: hidden;
+  position: relative
+  overflow: hidden
 
-  svg
+  .mermaid-zoom-wrapper > svg
     max-width: 100%
     height: auto
     border-radius: 0.5rem
-    user-select: none;
-    pointer-events: all;
+    user-select: none
+    pointer-events: all
 
 .mermaid-loading
   display: flex
@@ -323,7 +320,7 @@ a.card-github.fetch-error
 .dark .mermaid-diagram-container
   background: var(--card-bg)
 
-  svg
+  .mermaid-zoom-wrapper > svg
     filter: brightness(0.9) contrast(1.1)
 
 // 响应式设计
@@ -331,28 +328,160 @@ a.card-github.fetch-error
   .mermaid-wrapper
     padding: 1rem
 
-  .mermaid svg
+  .mermaid .mermaid-zoom-wrapper > svg
     max-height: 400px
 
 
-.mermaid-zoom-wrapper
-  transform-origin: 0 0;
-  transition: transform 120ms ease-out;
-  will-change: transform;
-  cursor: grab;
-  background: transparent;
+.mermaid-viewport
+  display: grid
+  width: 100%
+  min-height: 300px
+  place-items: center
+  overflow: hidden
+  box-sizing: border-box
+  cursor: grab
+  touch-action: none
+  overscroll-behavior: contain
 
-.mermaid-zoom-wrapper:active
-  cursor: grabbing;
+  &.is-panning
+    cursor: grabbing
+
+    .mermaid-zoom-wrapper
+      transition: none
+
+.mermaid-zoom-wrapper
+  display: flex
+  width: 100%
+  height: 100%
+  align-items: center
+  justify-content: center
+  transform-origin: 0 0
+  transition: transform 120ms ease-out
+  will-change: transform
+  background: transparent
 
 .mermaid-zoom-controls
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  display: flex;
-  gap: 6px;
-  z-index: 30;
-  user-select: none;
+  position: absolute
+  z-index: 30
+  top: .5rem
+  right: .5rem
+  display: flex
+  gap: .3rem
+  padding: .25rem
+  border: 1px solid var(--line-divider)
+  border-radius: .7rem
+  background: var(--card-bg)
+  box-shadow: 0 2px 8px rgba(0, 0, 0, .08)
+  user-select: none
+
+.mermaid-control, .mermaid-fullscreen-close
+  display: grid
+  width: 2.25rem
+  height: 2.25rem
+  flex: 0 0 auto
+  place-items: center
+  padding: 0
+  color: var(--btn-content)
+  border: 0
+  border-radius: .5rem
+  background: var(--btn-regular-bg)
+  cursor: pointer
+  font: inherit
+  line-height: 1
+  transition: color .15s ease, background-color .15s ease, transform .15s ease
+
+  &:hover
+    color: var(--primary)
+    background: var(--btn-regular-bg-hover)
+
+  &:active
+    transform: scale(.9)
+
+  &:focus-visible
+    outline: 2px solid var(--primary)
+    outline-offset: 2px
+
+.mermaid-fullscreen-overlay
+  position: fixed
+  z-index: 10000
+  inset: 0
+  display: flex
+  align-items: center
+  justify-content: center
+  box-sizing: border-box
+  padding: clamp(.75rem, 3vw, 1.75rem)
+  background: var(--mermaid-fs-backdrop, rgba(15, 23, 42, .9))
+  backdrop-filter: blur(6px)
+
+.mermaid-fullscreen-stage
+  position: relative
+  width: min(75rem, 100%)
+  height: 90vh
+  max-height: 100%
+  overflow: hidden
+  box-sizing: border-box
+  border: 1px solid var(--mermaid-fs-border, rgba(255, 255, 255, .08))
+  border-radius: 1rem
+  background: var(--mermaid-fs-surface, #0f172a)
+  box-shadow: 0 1.25rem 5rem rgba(0, 0, 0, .35)
+
+  .mermaid-viewport
+    width: 100%
+    height: 100%
+    min-height: 0
+    padding: 3.5rem 1rem 1rem
+
+  .mermaid-zoom-controls
+    top: .75rem
+    right: auto
+    bottom: auto
+    left: .75rem
+
+  .mermaid-zoom-wrapper > svg
+    width: 100%
+    height: 100%
+    min-height: 0
+    max-width: 100%
+    max-height: 100%
+
+.mermaid-fullscreen-close
+  position: absolute
+  z-index: 31
+  top: .75rem
+  right: .75rem
+  width: 2.5rem
+  height: 2.5rem
+  font-size: 1.5rem
+
+.mermaid-error button
+  margin-top: .5rem
+  padding: .25rem .5rem
+  color: white
+  border: 0
+  border-radius: .25rem
+  background: var(--primary)
+  cursor: pointer
+
+body.mermaid-fullscreen-open
+  overflow: hidden
+
+@media (max-width: 640px)
+  .mermaid-zoom-controls
+    gap: .2rem
+
+  .mermaid-control
+    width: 2rem
+    height: 2rem
+
+  .mermaid-fullscreen-overlay
+    padding: .5rem
+
+  .mermaid-fullscreen-stage
+    height: calc(100vh - 1rem)
+    border-radius: .75rem
+
+    .mermaid-viewport
+      padding: 3.25rem .5rem .5rem
 
 // Wiki Link 文章卡片
 a.card-wiki-link

--- a/tests/mermaid-interactions.test.mjs
+++ b/tests/mermaid-interactions.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { describe, it } from "node:test";
+
+import { rehypeMermaid } from "../src/plugins/rehype-mermaid.mjs";
+
+const layoutSource = await readFile(
+	new URL("../src/layouts/Layout.astro", import.meta.url),
+	"utf8",
+);
+const managerSource = await readFile(
+	new URL(
+		"../src/components/features/markdown/MermaidManager.astro",
+		import.meta.url,
+	),
+	"utf8",
+);
+const rehypeSource = await readFile(
+	new URL("../src/plugins/rehype-mermaid.mjs", import.meta.url),
+	"utf8",
+);
+const interactionSource = await readFile(
+	new URL("../src/plugins/mermaid-render-script.js", import.meta.url),
+	"utf8",
+);
+const markdownStyles = await readFile(
+	new URL("../src/styles/markdown-extend.styl", import.meta.url),
+	"utf8",
+);
+const expressiveCodeStyles = await readFile(
+	new URL("../src/styles/expressive-code.css", import.meta.url),
+	"utf8",
+);
+
+describe("Mermaid interaction regressions", () => {
+	it("loads one lazy Mermaid manager instead of embedding the runtime per diagram", () => {
+		assert.match(layoutSource, /import MermaidManager/);
+		assert.match(layoutSource, /<MermaidManager\s*\/>/);
+		assert.match(
+			managerSource,
+			/import "@\/plugins\/mermaid-render-script\.js"/,
+		);
+		assert.match(managerSource, /<script>/);
+		assert.doesNotMatch(managerSource, /is:inline|\?raw/);
+		assert.doesNotMatch(
+			rehypeSource,
+			/mermaidRenderScript|h\(\s*["']script["']/,
+		);
+		assert.match(interactionSource, /if \(window\.mermaid\?\.render\) return/);
+	});
+
+	it("emits only diagram markup from the Markdown transformer", () => {
+		const tree = {
+			type: "root",
+			children: [
+				{
+					type: "element",
+					tagName: "div",
+					properties: {
+						className: ["mermaid-container"],
+						"data-mermaid-code": "graph TD; A-->B",
+					},
+					children: [],
+				},
+			],
+		};
+
+		rehypeMermaid()(tree);
+		assert.equal(
+			tree.children[0].properties.class,
+			"mermaid-diagram-container",
+		);
+		assert.equal(tree.children[0].children.length, 1);
+		assert.equal(tree.children[0].children[0].tagName, "div");
+		assert.equal(tree.children[0].children[0].children[0].tagName, "div");
+	});
+
+	it("keeps fullscreen in the shared toolbar and the draggable viewport separate", () => {
+		assert.doesNotMatch(
+			interactionSource,
+			/injectFullscreenStyles|mermaid-fullscreen-btn/,
+		);
+		assert.match(interactionSource, /name: "fullscreen"/);
+		assert.match(
+			interactionSource,
+			/viewport\.addEventListener\(\s*"pointerdown"/s,
+		);
+		assert.match(
+			interactionSource,
+			/attachDiagramInteraction\(stage, clonedSvg\)/,
+		);
+		assert.match(
+			markdownStyles,
+			/\.mermaid-viewport\s+[\s\S]*?touch-action: none/,
+		);
+		assert.match(
+			markdownStyles,
+			/\.mermaid-fullscreen-stage[\s\S]*?\.mermaid-zoom-controls\s+top: \.75rem\s+right: auto\s+bottom: auto\s+left: \.75rem/,
+		);
+		assert.doesNotMatch(expressiveCodeStyles, /mermaid-fullscreen-btn/);
+	});
+
+	it("cleans up fullscreen listeners and restores keyboard focus", () => {
+		assert.match(interactionSource, /session\.eventController\.abort\(\)/);
+		assert.match(interactionSource, /session\.diagramController\.destroy\(\)/);
+		assert.match(
+			interactionSource,
+			/session\.previousFocus\.focus\(\{ preventScroll: true \}\)/,
+		);
+		assert.match(interactionSource, /aria-modal/);
+		assert.match(interactionSource, /event\.key === "Escape"/);
+	});
+});


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

Closes #532

## Changes

- 将 Mermaid 客户端运行时集中到单一的共享 `MermaidManager`，由 Astro 打包并仅在页面存在图表时加载 Mermaid CDN，移除每张图重复内嵌的完整运行时。
- 将放大、缩小、重置和全屏入口合并为稳定工具栏，修复首次加载错位、退出全屏后隐藏/覆盖的问题。
- 分离 toolbar 与 draggable viewport，修复全屏控件容器覆盖画布、拦截 pointer 事件导致无法拖拽的问题。
- 重构缩放和平移状态，支持鼠标、滚轮、Pointer Events 与触控，并以指针或画布中心为缩放锚点。
- 完善全屏响应式布局、Esc/背景关闭、焦点约束与恢复，以及主题切换、Swup 页面切换和重复渲染时的事件清理。
- 新增 Mermaid Markdown 转换、单实例运行时、viewport/toolbar 隔离和全屏生命周期回归测试。

## How To Test

- `pnpm test`
  - 27 个 Node 测试通过。
  - 8 个加密系统测试通过。
- `pnpm check`
  - 321 个文件，0 errors、0 warnings、0 hints。
- `pnpm build`
  - 生产构建、全局样式检查与 Pagefind 索引均通过。
  - Mermaid 示例页产物包含 6 个图表容器、1 个共享运行时、0 个旧内嵌运行时和 0 个运行时注入的全屏样式。
- `pnpm exec biome check` 与 `git diff --check` 通过。

## Screenshots (if applicable)

<img width="2514" height="1290" alt="image" src="https://github.com/user-attachments/assets/a8e27b5c-eafa-4d14-b31f-e8425f755449" />
<img width="1920" height="1050" alt="QQ20260807-201730-HD" src="https://github.com/user-attachments/assets/0e9bd7ac-52d8-4f14-86b1-14042510326b" />

在线预览：https://mizuki-b82cpc3zb-dawns-projects-37e0287f.vercel.app/posts/markdown-mermaid/

## Additional Notes

- `src/content/posts/markdown-mermaid.md` 的文章内容未修改。
- Mermaid CDN 仍为按需加载，并保留 jsDelivr → unpkg 的失败回退。
- 未提供未经验证的部署预览链接。