### PR TITLE
fix(markdown): 修复提示块标题与表格内容重叠

### DIFF
--- a/src/styles/markdown-extend.styl
+++ b/src/styles/markdown-extend.styl
@@ -1,10 +1,10 @@
 .custom-md
 
   blockquote.admonition
-    .bdm-title
+    > .bdm-title
       display: flex
       align-items: center
-      margin-bottom: -.9rem
+      margin-bottom: .5rem
       font-weight: bold
 
       &:before
@@ -20,6 +20,10 @@
         mask-position: center
         mask-repeat: no-repeat
         transform: translateY(-0.0625rem)
+
+    > .bdm-title + *
+      margin-top: 0
+
     &.bdm-tip
       .bdm-title
         color: var(--admonitions-color-tip)

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -18,6 +18,10 @@ const markdownSource = await readFile(
 	new URL("../src/components/misc/Markdown.astro", import.meta.url),
 	"utf8",
 );
+const markdownExtendStyles = await readFile(
+	new URL("../src/styles/markdown-extend.styl", import.meta.url),
+	"utf8",
+);
 const encryptorSource = await readFile(
 	new URL("../src/components/features/auth/Encryptor.astro", import.meta.url),
 	"utf8",
@@ -77,6 +81,26 @@ describe("Global style loading regressions", () => {
 		assert.match(globalStyleCheckSource, /about\/index\.html/);
 		assert.match(globalStyleCheckSource, /\.card-github/);
 		assert.match(globalStyleCheckSource, /\.custom-md \.image-grid/);
+	});
+});
+
+describe("Markdown layout regressions", () => {
+	it("keeps admonition titles separated from every first content block", () => {
+		assert.match(
+			markdownExtendStyles,
+			/> \.bdm-title\s+[\s\S]*?margin-bottom:\s*\.5rem/,
+			"admonition titles must provide their own positive content gap",
+		);
+		assert.match(
+			markdownExtendStyles,
+			/> \.bdm-title \+ \*\s+[\s\S]*?margin-top:\s*0/,
+			"the first admonition child must not add content-type-specific spacing",
+		);
+		assert.doesNotMatch(
+			markdownExtendStyles,
+			/\.bdm-title\s+[\s\S]*?margin-bottom:\s*-/,
+			"negative title margins pull marginless content such as tables into the title",
+		);
 	});
 });
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

Closes #538

## Changes

- 移除 admonition 标题用于抵消普通内容默认间距的 `-0.9rem` 负下外边距，避免零外边距的 `.table-wrapper` 被向上拉入标题区域。
- 将标题与内容之间的间距改为由标题自身提供稳定的 `0.5rem` 正向下外边距。
- 清除标题后第一个直接内容块的上外边距，使段落、列表、表格等不同内容类型获得一致间距。
- 增加 Markdown 布局回归测试，覆盖正向标题间距、首个内容块间距归一化，以及禁止重新引入负下外边距。

## How To Test

1. 在任意 admonition 中直接嵌入 Markdown 表格，并确认标题与表格顶部之间保持正常间距。
2. 检查以段落或列表开头的 admonition，确认原有内容布局没有额外叠加间距。
3. 已执行以下自动化验证：
   - `pnpm test`：50 项 Node 测试与 8 项加密测试全部通过。
   - `pnpm exec astro check`：0 errors、0 warnings、0 hints。
   - `pnpm exec astro build`：成功构建 26 个页面。
   - `pnpm exec biome check tests/layout-regressions.test.mjs`：通过。
4. 已检查构建产物，确认生成以下规则：
   - `.custom-md blockquote.admonition>.bdm-title{margin-bottom:.5rem}`
   - `.custom-md blockquote.admonition>.bdm-title+*{margin-top:0}`

## Screenshots (if applicable)

未附修复后截图；当前环境没有可连接的浏览器实例。已通过回归测试、Astro 检查、完整构建及最终 CSS 产物检查验证修复。

## Additional Notes

Markdown/Directive 生成的 DOM 结构本身正确，本次修复仅调整布局间距，不改变解析器、表格包装结构或 admonition 的语义标记。