### PR TITLE
fix(date): 统一文章日期的站点时区语义

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -272,6 +272,7 @@ export const siteConfig: SiteConfig = {
   title: "あなたのブログ名",
   subtitle: "あなたのブログの説明",
   lang: "ja", // または "zh-CN"、"en" など
+  timeZone: "Asia/Shanghai", // IANAタイムゾーン（例：Asia/Tokyo、Europe/Berlin）
   themeColor: {
     hue: 210, // 0-360、テーマの色相
     fixed: false, // テーマカラーピッカーを非表示

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ export const siteConfig: SiteConfig = {
   title: "Your Blog Name",
   subtitle: "Your Blog Description",
   lang: "en", // or "zh-CN", "ja", etc.
+  timeZone: "Asia/Shanghai", // IANA time zone, e.g. Asia/Tokyo or Europe/Berlin
   themeColor: {
     hue: 210, // 0-360, theme hue
     fixed: false, // Hide theme color picker

--- a/README.tw.md
+++ b/README.tw.md
@@ -272,6 +272,7 @@ export const siteConfig: SiteConfig = {
   title: "您的部落格名稱",
   subtitle: "您的部落格描述",
   lang: "zh-TW", // 或 "zh-CN"、"en"、"ja" 等
+  timeZone: "Asia/Shanghai", // IANA 時區，例如 Asia/Tokyo 或 Europe/Berlin
   themeColor: {
     hue: 210, // 0-360，主題色調
     fixed: false, // 隱藏主題色選擇器

--- a/README.zh.md
+++ b/README.zh.md
@@ -273,6 +273,7 @@ export const siteConfig: SiteConfig = {
   title: "您的博客名称",
   subtitle: "您的博客描述",
   lang: "zh-CN", // 或 "en"、"ja" 等
+  timeZone: "Asia/Shanghai", // IANA 时区，例如 Asia/Tokyo 或 Europe/Berlin
   themeColor: {
     hue: 210, // 0-360，主题色调
     fixed: false, // 隐藏主题色选择器

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "type-check": "tsc --noEmit",
-    "test": "node --experimental-strip-types --test tests/content-pipeline.test.mjs tests/content-links.test.ts tests/feed-content.test.ts tests/post-cover-source.test.ts tests/markdown-enhancements.test.mjs tests/layout-regressions.test.mjs tests/mermaid-interactions.test.mjs tests/image-loading.test.mjs tests/music-player-loading.test.mjs tests/font-loading.test.mjs && node tests/crypto.test.mjs",
+    "test": "node --experimental-strip-types --test tests/content-pipeline.test.mjs tests/content-links.test.ts tests/feed-content.test.ts tests/post-cover-source.test.ts tests/post-date-utils.test.ts tests/markdown-enhancements.test.mjs tests/layout-regressions.test.mjs tests/mermaid-interactions.test.mjs tests/image-loading.test.mjs tests/music-player-loading.test.mjs tests/font-loading.test.mjs && node tests/crypto.test.mjs",
     "prepare-fonts": "node scripts/prepare-fonts.mjs",
     "check-fonts": "node scripts/check-font-loading.mjs",
     "prepare-images": "node scripts/prepare-default-images.mjs",

--- a/src/components/features/archive/ArchivePanel.svelte
+++ b/src/components/features/archive/ArchivePanel.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import I18nKey from "@i18n/i18nKey";
 import { i18n } from "@i18n/translation";
+import { formatDateToYYYYMMDD, getPostDateParts } from "@utils/date-utils";
+import { comparePublishedDatesDescending } from "@utils/post-date-utils";
 import { onMount } from "svelte";
 import type { ArchivePanelProps, Group, Post } from "./types";
 
@@ -17,10 +19,8 @@ const uncategorized = params.get("uncategorized");
 
 let groups = $state<Group[]>([]);
 
-function formatDate(date: Date) {
-	const month = (date.getMonth() + 1).toString().padStart(2, "0");
-	const day = date.getDate().toString().padStart(2, "0");
-	return `${month}-${day}`;
+function formatDate(date: Date, dateOnly: boolean) {
+	return formatDateToYYYYMMDD(date, dateOnly).slice(5);
 }
 
 function formatTag(tagList: string[]) {
@@ -51,11 +51,21 @@ onMount(async () => {
 	// 按发布时间倒序排序，确保不受置顶影响
 	filteredPosts = filteredPosts
 		.slice()
-		.sort((a, b) => b.data.published.getTime() - a.data.published.getTime());
+		.sort((a, b) =>
+			comparePublishedDatesDescending(
+				a.data.published,
+				b.data.published,
+				a.id,
+				b.id,
+			),
+		);
 
 	const grouped = filteredPosts.reduce(
 		(acc, post) => {
-			const year = post.data.published.getFullYear();
+			const year = getPostDateParts(
+				post.data.published,
+				post.data._publishedDateOnly,
+			).year;
 			if (!acc[year]) {
 				acc[year] = [];
 			}
@@ -114,7 +124,7 @@ onMount(async () => {
 						<div
 							class="w-[15%] md:w-[10%] transition text-sm text-right text-50"
 						>
-							{formatDate(post.data.published)}
+							{formatDate(post.data.published, post.data._publishedDateOnly)}
 						</div>
 
 						<!-- dot and line -->

--- a/src/components/features/archive/types.ts
+++ b/src/components/features/archive/types.ts
@@ -12,6 +12,7 @@ export interface Post {
 		tags: string[];
 		category?: string;
 		published: Date;
+		_publishedDateOnly: boolean;
 		alias?: string;
 		permalink?: string;
 	};

--- a/src/components/features/posts/LastModified.astro
+++ b/src/components/features/posts/LastModified.astro
@@ -2,19 +2,15 @@
 import I18nKey from "@i18n/i18nKey";
 import { i18n } from "@i18n/translation";
 import { Icon } from "astro-icon/components";
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
 
 interface Props {
 	updatedDate: Date;
 	class?: string;
 }
 
-dayjs.extend(utc);
-
 const { updatedDate, class: className } = Astro.props;
 
-const lastModified = dayjs(updatedDate).utc().format("YYYY-MM-DDTHH:mm:ss");
+const lastModified = updatedDate.toISOString();
 ---
 
 <>

--- a/src/components/features/posts/PostCard.astro
+++ b/src/components/features/posts/PostCard.astro
@@ -19,7 +19,9 @@ const className = Astro.props.class;
 const {
 	title,
 	published,
+	_publishedDateOnly,
 	updated,
+	_updatedDateOnly,
 	tags,
 	category,
 	description,
@@ -102,7 +104,9 @@ const homeContent = getPostHomeContent(
 
 		<PostMetadata
 			published={published}
+			publishedDateOnly={_publishedDateOnly}
 			updated={updated}
+			updatedDateOnly={_updatedDateOnly}
 			tags={tags}
 			category={category || ""}
 			hideTagsForMobile={true}

--- a/src/components/features/posts/PostListItem.astro
+++ b/src/components/features/posts/PostListItem.astro
@@ -24,10 +24,10 @@ const {
 
 const displayDate =
 	dateFormat === "iso"
-		? post.data.published.toISOString().substring(0, 10)
+		? formatDateToYYYYMMDD(post.data.published, post.data._publishedDateOnly)
 		: getPostPublicDescription(
 				post.data,
-				formatDateToYYYYMMDD(post.data.published),
+				formatDateToYYYYMMDD(post.data.published, post.data._publishedDateOnly),
 			);
 ---
 

--- a/src/components/features/posts/PostMeta.astro
+++ b/src/components/features/posts/PostMeta.astro
@@ -15,7 +15,9 @@ import {
 
 interface Props {
 	published: Date;
+	publishedDateOnly?: boolean;
 	updated?: Date;
+	updatedDateOnly?: boolean;
 	category?: string;
 	tags?: string[];
 	hideUpdateDate?: boolean;
@@ -33,7 +35,9 @@ interface Props {
 
 const {
 	published,
+	publishedDateOnly = false,
 	updated,
+	updatedDateOnly = false,
 	category,
 	tags,
 	hideUpdateDate,
@@ -51,14 +55,14 @@ const {
 ---
 
 <div class:list={["flex flex-wrap text-neutral-500 dark:text-neutral-400 items-center gap-4 gap-x-4 gap-y-2", className]}>
-    <PublishedDate date={published} />
+    <PublishedDate date={published} dateOnly={publishedDateOnly} />
 
     {!hideUpdateDate && updated && updated.getTime() !== published.getTime() && (
         <div class="flex items-center">
             <div class="meta-icon">
                 <Icon name="material-symbols:edit-calendar-outline-rounded" class="text-xl"></Icon>
             </div>
-            <span class="text-50 text-sm font-medium">{formatDateToYYYYMMDD(updated)}</span>
+            <span class="text-50 text-sm font-medium">{formatDateToYYYYMMDD(updated, updatedDateOnly)}</span>
         </div>
     )}
 

--- a/src/components/features/posts/atoms/PublishedDate.astro
+++ b/src/components/features/posts/atoms/PublishedDate.astro
@@ -5,10 +5,11 @@ import { formatDateToYYYYMMDD } from "@/utils/date-utils";
 
 interface Props {
 	date: Date;
+	dateOnly?: boolean;
 	class?: string;
 }
 
-const { date, class: className } = Astro.props;
+const { date, dateOnly = false, class: className } = Astro.props;
 ---
 
 <div class:list={["flex items-center", className]}>
@@ -18,6 +19,6 @@ const { date, class: className } = Astro.props;
 			class="text-xl"
 		/>
 	</div>
-	<span class="text-50 text-sm font-medium">{formatDateToYYYYMMDD(date)}</span
+	<span class="text-50 text-sm font-medium">{formatDateToYYYYMMDD(date, dateOnly)}</span
 	>
 </div>

--- a/src/components/features/posts/types.ts
+++ b/src/components/features/posts/types.ts
@@ -9,7 +9,9 @@ export interface PostCardProps {
 
 export interface PostMetaProps {
 	published: Date;
+	publishedDateOnly?: boolean;
 	updated?: Date;
+	updatedDateOnly?: boolean;
 	category?: string;
 	tags?: string[];
 	hideUpdateDate?: boolean;

--- a/src/components/misc/License.astro
+++ b/src/components/misc/License.astro
@@ -10,6 +10,7 @@ interface Props {
 	title: string;
 	id: string;
 	pubDate: Date;
+	pubDateOnly?: boolean;
 	class: string;
 	author: string;
 	sourceLink: string;
@@ -17,8 +18,15 @@ interface Props {
 	licenseUrl: string;
 }
 
-const { title, pubDate, author, sourceLink, licenseName, licenseUrl } =
-	Astro.props;
+const {
+	title,
+	pubDate,
+	pubDateOnly = false,
+	author,
+	sourceLink,
+	licenseName,
+	licenseUrl,
+} = Astro.props;
 const className = Astro.props.class;
 const profileConf = profileConfig;
 const licenseConf = licenseConfig;
@@ -52,7 +60,7 @@ const postUrl = sourceLink || decodeURIComponent(Astro.url.toString());
 			<div
 				class="transition text-black/75 dark:text-white/75 line-clamp-2"
 			>
-				{formatDateToYYYYMMDD(pubDate)}
+				{formatDateToYYYYMMDD(pubDate, pubDateOnly)}
 			</div>
 		</div>
 		<div>

--- a/src/components/widgets/feed/FeedInfo.astro
+++ b/src/components/widgets/feed/FeedInfo.astro
@@ -116,7 +116,10 @@ const t = (key: string) => i18n(key as I18nKey);
 									datetime={post.data.published.toISOString()}
 									class="text-75"
 								>
-									{formatDateToYYYYMMDD(post.data.published)}
+									{formatDateToYYYYMMDD(
+										post.data.published,
+										post.data._publishedDateOnly,
+									)}
 								</time>
 							</div>
 						</article>

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -8,6 +8,7 @@ export const siteConfig: SiteConfig = {
 	subtitle: "One demo website",
 	siteURL: "https://mizuki.mysqil.com/", // 请替换为你的站点URL，以斜杠结尾
 	siteStartDate: "2025-01-01", // 站点开始运行日期，用于站点统计组件计算运行天数
+	timeZone: "Asia/Shanghai", // 文章日期使用的 IANA 时区，可改为 Asia/Tokyo、Europe/Berlin 等
 
 	lang: SITE_LANG,
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -2,8 +2,10 @@ import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
 import { z } from "astro/zod";
 
+import { postGlob } from "./loaders/post-loader";
+
 const postsCollection = defineCollection({
-	loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/posts" }),
+	loader: postGlob({ pattern: "**/*.{md,mdx}", base: "./src/content/posts" }),
 	schema: z.object({
 		title: z.string(),
 		published: z.date(),
@@ -39,6 +41,8 @@ const postsCollection = defineCollection({
 		prevSlug: z.string().default(""),
 		nextTitle: z.string().default(""),
 		nextSlug: z.string().default(""),
+		_publishedDateOnly: z.boolean(),
+		_updatedDateOnly: z.boolean(),
 	}),
 });
 const specCollection = defineCollection({

--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -38,6 +38,7 @@ interface Props {
 	headings?: MarkdownHeading[];
 	coverImage?: string;
 	publishedDate?: Date;
+	publishedDateOnly?: boolean;
 	category?: string;
 	wordCount?: number;
 }
@@ -55,6 +56,7 @@ const {
 	coverImage,
 	headings = [],
 	publishedDate,
+	publishedDateOnly = false,
 	category,
 	wordCount,
 } = Astro.props;
@@ -239,7 +241,7 @@ const defaultPostListLayout = siteConfig.postListLayout?.defaultMode || "list";
 						<div
 							id="page-overlay-data"
 							data-title={title || ""}
-							data-date={publishedDate ? formatDateToYYYYMMDD(publishedDate) : ""}
+							data-date={publishedDate ? formatDateToYYYYMMDD(publishedDate, publishedDateOnly) : ""}
 							data-category={category || ""}
 							data-words={wordCount ? String(wordCount) : ""}
 							data-is-post={postSlug ? "true" : "false"}

--- a/src/loaders/post-loader.ts
+++ b/src/loaders/post-loader.ts
@@ -1,0 +1,53 @@
+import { readFile } from "node:fs/promises";
+import { glob } from "astro/loaders";
+import { extractFrontmatter } from "astro/markdown";
+
+import { isDateOnlyFrontmatterField } from "../utils/frontmatter-date";
+
+type GlobOptions = Parameters<typeof glob>[0];
+
+interface ParseDataOptions<TData extends Record<string, unknown>> {
+	id: string;
+	data: TData;
+	filePath?: string;
+}
+
+export function postGlob(options: GlobOptions): ReturnType<typeof glob> {
+	const loader = glob(options);
+
+	return {
+		...loader,
+		name: "mizuki-post-glob-loader",
+		async load(context) {
+			await loader.load({
+				...context,
+				parseData: async <TData extends Record<string, unknown>>(
+					props: ParseDataOptions<TData>,
+				): Promise<TData> => {
+					if (!props.filePath) {
+						throw new Error(`Post ${props.id} is missing its source file path`);
+					}
+
+					const source = await readFile(props.filePath, "utf8");
+					const rawFrontmatter = extractFrontmatter(source) ?? "";
+					const data = {
+						...props.data,
+						_publishedDateOnly: isDateOnlyFrontmatterField(
+							rawFrontmatter,
+							"published",
+						),
+						_updatedDateOnly: isDateOnlyFrontmatterField(
+							rawFrontmatter,
+							"updated",
+						),
+					};
+
+					return (await context.parseData({
+						...props,
+						data,
+					})) as TData;
+				},
+			});
+		},
+	};
+}

--- a/src/pages/[...permalink].astro
+++ b/src/pages/[...permalink].astro
@@ -36,7 +36,6 @@ import { licenseConfig } from "src/config";
 import { permalinkConfig } from "@/config";
 
 import { profileConfig, siteConfig } from "../config";
-import { formatDateToYYYYMMDD } from "../utils/date-utils";
 
 export async function getStaticPaths() {
 	const blogEntries = await getSortedPosts();
@@ -105,7 +104,10 @@ const jsonLd = {
 		name: profileConfig.name,
 		url: Astro.site,
 	},
-	datePublished: formatDateToYYYYMMDD(entry.data.published),
+	datePublished: entry.data.published.toISOString(),
+	...(entry.data.updated && {
+		dateModified: entry.data.updated.toISOString(),
+	}),
 	inLanguage: entry.data.lang
 		? entry.data.lang.replace("_", "-")
 		: siteConfig.lang.replace("_", "-"),
@@ -121,6 +123,7 @@ const jsonLd = {
 	postSlug={entry.id}
 	headings={headings}
 	publishedDate={entry.data.published}
+	publishedDateOnly={entry.data._publishedDateOnly}
 	category={entry.data.category || undefined}
 	wordCount={remarkPluginFrontmatter.words}
 >
@@ -201,7 +204,9 @@ const jsonLd = {
 				<PostMeta
 					className="mb-5"
 					published={entry.data.published}
+					publishedDateOnly={entry.data._publishedDateOnly}
 					updated={entry.data.updated}
+					updatedDateOnly={entry.data._updatedDateOnly}
 					tags={entry.data.tags}
 					category={entry.data.category || undefined}
 					id={entry.id}
@@ -252,6 +257,7 @@ const jsonLd = {
 								title={entry.data.title}
 								id={entry.id}
 								pubDate={entry.data.published}
+								pubDateOnly={entry.data._publishedDateOnly}
 								author={entry.data.author}
 								sourceLink={entry.data.sourceLink}
 								licenseName={entry.data.licenseName}

--- a/src/pages/api/allPostMeta.json.ts
+++ b/src/pages/api/allPostMeta.json.ts
@@ -14,7 +14,13 @@ export async function GET() {
 			password: !!post.data.password,
 		}))
 		// 按发布日期降序排列
-		.sort((a, b) => b.published - a.published);
+		.sort((a, b) => {
+			const timeDifference = b.published - a.published;
+			if (timeDifference !== 0) {
+				return timeDifference;
+			}
+			return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+		});
 
 	return new Response(JSON.stringify(allPostsData), {
 		headers: { "Content-Type": "application/json" },

--- a/src/pages/api/calendar-data.json.ts
+++ b/src/pages/api/calendar-data.json.ts
@@ -1,18 +1,17 @@
 import { getSortedPosts } from "../../utils/content-utils";
+import { formatDateToYYYYMMDD } from "../../utils/date-utils";
 
 export async function GET() {
 	const posts = await getSortedPosts();
 
 	const allPostsData = posts.map((post) => {
-		const date = new Date(post.data.published);
-		const year = date.getFullYear();
-		const month = String(date.getMonth() + 1).padStart(2, "0");
-		const day = String(date.getDate()).padStart(2, "0");
-
 		return {
 			id: post.id,
 			title: post.data.title,
-			date: `${year}-${month}-${day}`,
+			date: formatDateToYYYYMMDD(
+				post.data.published,
+				post.data._publishedDateOnly,
+			),
 		};
 	});
 

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -21,6 +21,7 @@ const posts = sortedPostsList.map((post) => ({
 		tags: post.data.tags,
 		category: post.data.category === null ? undefined : post.data.category,
 		published: post.data.published,
+		_publishedDateOnly: post.data._publishedDateOnly,
 		alias: post.data.alias,
 		permalink: post.data.permalink,
 	},

--- a/src/pages/og/[...slug].ts
+++ b/src/pages/og/[...slug].ts
@@ -2,13 +2,12 @@ import type { CollectionEntry } from "astro:content";
 import { getCollection } from "astro:content";
 import * as fs from "node:fs";
 import type { APIContext, GetStaticPaths } from "astro";
-
+import { type Font, setGlyphCacheMaxBytes } from "takumi-js";
+import { ImageResponse } from "takumi-js/response";
+import { formatDateWithLocale } from "@/utils/date-utils";
 import { getPostPublicDescription } from "@/utils/post-card-content";
 import { removeFileExtension } from "@/utils/url-utils";
-
 import { profileConfig, siteConfig } from "../../config";
-import { ImageResponse } from "takumi-js/response";
-import { setGlyphCacheMaxBytes, type Font } from "takumi-js";
 
 setGlyphCacheMaxBytes(32 * 1024 * 1024);
 
@@ -123,11 +122,16 @@ export async function GET({
 	const subtleTextColor = `hsl(${hue}, 10%, 75%)`;
 	const backgroundColor = `hsl(${hue}, 15%, 12%)`;
 
-	const pubDate = post.data.published.toLocaleDateString("en-US", {
-		year: "numeric",
-		month: "short",
-		day: "numeric",
-	});
+	const pubDate = formatDateWithLocale(
+		post.data.published,
+		"en-US",
+		{
+			year: "numeric",
+			month: "short",
+			day: "numeric",
+		},
+		post.data._publishedDateOnly,
+	);
 
 	const description = getPostPublicDescription(post.data);
 

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -201,7 +201,10 @@ const jsonLd = {
 		name: profileConfig.name,
 		url: Astro.site,
 	},
-	datePublished: formatDateToYYYYMMDD(entry.data.published),
+	datePublished: entry.data.published.toISOString(),
+	...(entry.data.updated && {
+		dateModified: entry.data.updated.toISOString(),
+	}),
 	inLanguage: entry.data.lang
 		? entry.data.lang.replace("_", "-")
 		: siteConfig.lang.replace("_", "-"),
@@ -219,6 +222,7 @@ const jsonLd = {
 	headings={headings}
 	coverImage={ogCoverUrl}
 	publishedDate={entry.data.published}
+	publishedDateOnly={entry.data._publishedDateOnly}
 	category={entry.data.category || undefined}
 	wordCount={remarkPluginFrontmatter.words}
 >
@@ -281,7 +285,9 @@ const jsonLd = {
 				<PostMeta
 					className="mb-5"
 					published={entry.data.published}
+					publishedDateOnly={entry.data._publishedDateOnly}
 					updated={entry.data.updated}
+					updatedDateOnly={entry.data._updatedDateOnly}
 					tags={entry.data.tags}
 					category={entry.data.category || undefined}
 					id={entry.id}
@@ -339,7 +345,10 @@ const jsonLd = {
 						title={entry.data.title}
 						author={entry.data.author}
 						description={publicDescription}
-						pubDate={formatDateToYYYYMMDD(entry.data.published)}
+						pubDate={formatDateToYYYYMMDD(
+							entry.data.published,
+							entry.data._publishedDateOnly,
+						)}
 						coverImage={posterCoverUrl}
 						url={Astro.url.toString()}
 						siteTitle={siteConfig.title}
@@ -361,6 +370,7 @@ const jsonLd = {
 							title={entry.data.title}
 							id={entry.id}
 							pubDate={entry.data.published}
+							pubDateOnly={entry.data._publishedDateOnly}
 
 							author={entry.data.author}
 							sourceLink={entry.data.sourceLink}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -13,6 +13,7 @@ export interface SiteConfig {
 	siteURL: string; // 站点URL，以斜杠结尾，例如：https://mizuki.mysqil.com/
 	keywords?: string[]; // 站点关键词，用于生成 <meta name="keywords">
 	siteStartDate?: string; // 站点开始日期，格式：YYYY-MM-DD，用于计算运行天数
+	timeZone: string; // IANA 时区，用于将文章时间转换为站点日历日期
 
 	lang:
 		| "en"

--- a/src/utils/content-utils.ts
+++ b/src/utils/content-utils.ts
@@ -2,6 +2,7 @@ import { type CollectionEntry, getCollection } from "astro:content";
 import I18nKey from "@i18n/i18nKey";
 import { i18n } from "@i18n/translation";
 import { initPostIdMap } from "@utils/permalink-utils";
+import { comparePublishedDatesDescending } from "@utils/post-date-utils";
 import { getCategoryUrl, getPostUrl } from "@utils/url-utils";
 
 // // Retrieve posts and sort them by publication date
@@ -35,9 +36,12 @@ async function getRawSortedPosts() {
 		}
 
 		// 否则按发布日期排序
-		const dateA = new Date(a.data.published);
-		const dateB = new Date(b.data.published);
-		return dateA > dateB ? -1 : 1;
+		return comparePublishedDatesDescending(
+			a.data.published,
+			b.data.published,
+			a.id,
+			b.id,
+		);
 	});
 	return sorted;
 }

--- a/src/utils/date-utils.ts
+++ b/src/utils/date-utils.ts
@@ -1,7 +1,21 @@
 import { siteConfig } from "../config";
+import { isDateOnlyString } from "./frontmatter-date";
+import {
+	assertValidTimeZone,
+	formatPostDateInTimeZone,
+	formatPostDateWithLocale,
+	getPostDatePartsInTimeZone,
+	type PostDateParts,
+} from "./post-date-utils";
 
-export function formatDateToYYYYMMDD(date: Date): string {
-	return date.toISOString().substring(0, 10);
+assertValidTimeZone(siteConfig.timeZone);
+
+export function getPostDateParts(date: Date, dateOnly = false): PostDateParts {
+	return getPostDatePartsInTimeZone(date, siteConfig.timeZone, dateOnly);
+}
+
+export function formatDateToYYYYMMDD(date: Date, dateOnly = false): string {
+	return formatPostDateInTimeZone(date, siteConfig.timeZone, dateOnly);
 }
 
 // 国际化日期格式化函数
@@ -35,5 +49,26 @@ export function formatDateI18n(dateString: string): string {
 	};
 
 	const locale = localeMap[lang] || "en-US";
-	return date.toLocaleDateString(locale, options);
+	return formatPostDateWithLocale(
+		date,
+		locale,
+		siteConfig.timeZone,
+		options,
+		isDateOnlyString(dateString),
+	);
+}
+
+export function formatDateWithLocale(
+	date: Date,
+	locale: string,
+	options: Intl.DateTimeFormatOptions,
+	dateOnly = false,
+): string {
+	return formatPostDateWithLocale(
+		date,
+		locale,
+		siteConfig.timeZone,
+		options,
+		dateOnly,
+	);
 }

--- a/src/utils/frontmatter-date.ts
+++ b/src/utils/frontmatter-date.ts
@@ -1,0 +1,34 @@
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isDateOnlyString(value: string): boolean {
+	return DATE_ONLY_PATTERN.test(value.trim());
+}
+
+export function getFrontmatterScalar(
+	rawFrontmatter: string,
+	field: string,
+): string | undefined {
+	const escapedField = field.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const match = rawFrontmatter.match(
+		new RegExp(`^${escapedField}\\s*:\\s*(.+?)\\s*$`, "m"),
+	);
+	if (!match) {
+		return undefined;
+	}
+
+	const rawValue = match[1].trim();
+	const quoted = rawValue.match(/^(["'])(.*?)\1(?:\s+#.*)?$/);
+	if (quoted) {
+		return quoted[2];
+	}
+
+	return rawValue.replace(/\s+#.*$/, "").trim();
+}
+
+export function isDateOnlyFrontmatterField(
+	rawFrontmatter: string,
+	field: string,
+): boolean {
+	const value = getFrontmatterScalar(rawFrontmatter, field);
+	return value !== undefined && isDateOnlyString(value);
+}

--- a/src/utils/permalink-utils.ts
+++ b/src/utils/permalink-utils.ts
@@ -1,6 +1,8 @@
 import type { CollectionEntry } from "astro:content";
 
 import { permalinkConfig } from "../config";
+import { getPostDateParts } from "./date-utils";
+import { comparePublishedDatesAscending } from "./post-date-utils";
 import { removeFileExtension } from "./url-utils";
 
 // 文章 ID 映射缓存（用于存储按时间排序后的文章序号）
@@ -19,8 +21,13 @@ export function initPostIdMap(
 	}
 
 	// 按发布时间升序排序（最早的在前）
-	const sortedPosts = [...posts].sort(
-		(a, b) => a.data.published.getTime() - b.data.published.getTime(),
+	const sortedPosts = [...posts].sort((a, b) =>
+		comparePublishedDatesAscending(
+			a.data.published,
+			b.data.published,
+			a.id,
+			b.id,
+		),
 	);
 
 	postIdMap = new Map();
@@ -80,6 +87,10 @@ export function generatePermalinkSlug(post: CollectionEntry<"posts">): string {
 	const format = permalinkConfig.format;
 
 	const published = post.data.published;
+	const publishedParts = getPostDateParts(
+		published,
+		post.data._publishedDateOnly,
+	);
 	const postname = removeFileExtension(post.id);
 
 	let rawPostname = postname;
@@ -95,15 +106,12 @@ export function generatePermalinkSlug(post: CollectionEntry<"posts">): string {
 
 	// 替换占位符
 	const slug = format
-		.replace(/%year%/g, published.getFullYear().toString())
-		.replace(
-			/%monthnum%/g,
-			(published.getMonth() + 1).toString().padStart(2, "0"),
-		)
-		.replace(/%day%/g, published.getDate().toString().padStart(2, "0"))
-		.replace(/%hour%/g, published.getHours().toString().padStart(2, "0"))
-		.replace(/%minute%/g, published.getMinutes().toString().padStart(2, "0"))
-		.replace(/%second%/g, published.getSeconds().toString().padStart(2, "0"))
+		.replace(/%year%/g, publishedParts.year.toString())
+		.replace(/%monthnum%/g, publishedParts.month.toString().padStart(2, "0"))
+		.replace(/%day%/g, publishedParts.day.toString().padStart(2, "0"))
+		.replace(/%hour%/g, publishedParts.hour.toString().padStart(2, "0"))
+		.replace(/%minute%/g, publishedParts.minute.toString().padStart(2, "0"))
+		.replace(/%second%/g, publishedParts.second.toString().padStart(2, "0"))
 		.replace(/%post_id%/g, getPostNumericId(post.id).toString())
 		.replace(/%postname%/g, postname)
 		.replace(/%raw_postname%/g, rawPostname)

--- a/src/utils/post-date-utils.ts
+++ b/src/utils/post-date-utils.ts
@@ -1,0 +1,147 @@
+export interface PostDateParts {
+	year: number;
+	month: number;
+	day: number;
+	hour: number;
+	minute: number;
+	second: number;
+}
+
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function assertValidDate(date: Date): void {
+	if (Number.isNaN(date.getTime())) {
+		throw new RangeError("Invalid published date");
+	}
+}
+
+function getFormatter(timeZone: string): Intl.DateTimeFormat {
+	const cached = formatterCache.get(timeZone);
+	if (cached) {
+		return cached;
+	}
+
+	const formatter = new Intl.DateTimeFormat("en-US-u-ca-gregory-nu-latn", {
+		timeZone,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+		hourCycle: "h23",
+	});
+	formatterCache.set(timeZone, formatter);
+	return formatter;
+}
+
+export function assertValidTimeZone(timeZone: string): void {
+	getFormatter(timeZone);
+}
+
+function getNumericPart(
+	parts: Intl.DateTimeFormatPart[],
+	type: Intl.DateTimeFormatPartTypes,
+): number {
+	const value = parts.find((part) => part.type === type)?.value;
+	if (value === undefined) {
+		throw new RangeError(`Unable to format published date part: ${type}`);
+	}
+	return Number.parseInt(value, 10);
+}
+
+/**
+ * 将文章时间转换为统一的站点日历时间。
+ *
+ * 纯日期保留其 UTC 年月日；带时间的值按显式 IANA 时区转换。该规则不读取
+ * 构建服务器或浏览器的本地时区，因此静态构建和客户端渲染结果一致。
+ */
+export function getPostDatePartsInTimeZone(
+	date: Date,
+	timeZone: string,
+	dateOnly = false,
+): PostDateParts {
+	assertValidDate(date);
+
+	if (dateOnly) {
+		return {
+			year: date.getUTCFullYear(),
+			month: date.getUTCMonth() + 1,
+			day: date.getUTCDate(),
+			hour: 0,
+			minute: 0,
+			second: 0,
+		};
+	}
+
+	const parts = getFormatter(timeZone).formatToParts(date);
+	return {
+		year: getNumericPart(parts, "year"),
+		month: getNumericPart(parts, "month"),
+		day: getNumericPart(parts, "day"),
+		hour: getNumericPart(parts, "hour"),
+		minute: getNumericPart(parts, "minute"),
+		second: getNumericPart(parts, "second"),
+	};
+}
+
+export function formatPostDateInTimeZone(
+	date: Date,
+	timeZone: string,
+	dateOnly = false,
+): string {
+	const { year, month, day } = getPostDatePartsInTimeZone(
+		date,
+		timeZone,
+		dateOnly,
+	);
+	return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+export function formatPostDateWithLocale(
+	date: Date,
+	locale: string,
+	timeZone: string,
+	options: Intl.DateTimeFormatOptions,
+	dateOnly = false,
+): string {
+	assertValidDate(date);
+	return new Intl.DateTimeFormat(locale, {
+		...options,
+		timeZone: dateOnly ? "UTC" : timeZone,
+	}).format(date);
+}
+
+function compareIds(idA: string, idB: string): number {
+	if (idA < idB) {
+		return -1;
+	}
+	if (idA > idB) {
+		return 1;
+	}
+	return 0;
+}
+
+export function comparePublishedDatesDescending(
+	dateA: Date,
+	dateB: Date,
+	idA: string,
+	idB: string,
+): number {
+	assertValidDate(dateA);
+	assertValidDate(dateB);
+	const timeDifference = dateB.getTime() - dateA.getTime();
+	return timeDifference === 0 ? compareIds(idA, idB) : timeDifference;
+}
+
+export function comparePublishedDatesAscending(
+	dateA: Date,
+	dateB: Date,
+	idA: string,
+	idB: string,
+): number {
+	assertValidDate(dateA);
+	assertValidDate(dateB);
+	const timeDifference = dateA.getTime() - dateB.getTime();
+	return timeDifference === 0 ? compareIds(idA, idB) : timeDifference;
+}

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -26,6 +26,13 @@ const encryptorSource = await readFile(
 	new URL("../src/components/features/auth/Encryptor.astro", import.meta.url),
 	"utf8",
 );
+const lastModifiedSource = await readFile(
+	new URL(
+		"../src/components/features/posts/LastModified.astro",
+		import.meta.url,
+	),
+	"utf8",
+);
 const globalStyleCheckSource = await readFile(
 	new URL("../scripts/check-global-style-loading.mjs", import.meta.url),
 	"utf8",
@@ -101,6 +108,42 @@ describe("Markdown layout regressions", () => {
 			/\.bdm-title\s+[\s\S]*?margin-bottom:\s*-/,
 			"negative title margins pull marginless content such as tables into the title",
 		);
+	});
+});
+
+describe("Last modified time regressions", () => {
+	it("preserves the updated instant across visitor time zones", () => {
+		assert.match(
+			lastModifiedSource,
+			/const lastModified = updatedDate\.toISOString\(\);/,
+			"the browser must receive an ISO timestamp with an explicit UTC designator",
+		);
+		assert.doesNotMatch(
+			lastModifiedSource,
+			/\.format\(["']YYYY-MM-DDTHH:mm:ss["']\)/,
+			"a timezone-less timestamp would be parsed as the visitor's local time",
+		);
+
+		const instant = new Date("2026-06-15T03:14:03+08:00");
+		const serialized = instant.toISOString();
+		const originalTimeZone = process.env.TZ;
+		try {
+			for (const visitorTimeZone of [
+				"UTC",
+				"Asia/Shanghai",
+				"Europe/Berlin",
+				"America/Los_Angeles",
+			]) {
+				process.env.TZ = visitorTimeZone;
+				assert.equal(new Date(serialized).getTime(), instant.getTime());
+			}
+		} finally {
+			if (originalTimeZone === undefined) {
+				delete process.env.TZ;
+			} else {
+				process.env.TZ = originalTimeZone;
+			}
+		}
 	});
 });
 

--- a/tests/post-date-utils.test.ts
+++ b/tests/post-date-utils.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+	getFrontmatterScalar,
+	isDateOnlyFrontmatterField,
+} from "../src/utils/frontmatter-date.ts";
+import {
+	assertValidTimeZone,
+	comparePublishedDatesAscending,
+	comparePublishedDatesDescending,
+	formatPostDateInTimeZone,
+	formatPostDateWithLocale,
+	getPostDatePartsInTimeZone,
+} from "../src/utils/post-date-utils.ts";
+
+describe("post date formatting", () => {
+	it("keeps date-only frontmatter stable across host and site time zones", () => {
+		const originalTimeZone = process.env.TZ;
+		try {
+			for (const hostTimeZone of [
+				"UTC",
+				"Asia/Shanghai",
+				"America/Los_Angeles",
+			]) {
+				process.env.TZ = hostTimeZone;
+				const published = new Date("2026-06-15");
+				for (const siteTimeZone of [
+					"UTC",
+					"Asia/Shanghai",
+					"Europe/Berlin",
+					"America/New_York",
+				]) {
+					assert.equal(
+						formatPostDateInTimeZone(published, siteTimeZone, true),
+						"2026-06-15",
+					);
+				}
+			}
+		} finally {
+			if (originalTimeZone === undefined) {
+				delete process.env.TZ;
+			} else {
+				process.env.TZ = originalTimeZone;
+			}
+		}
+	});
+
+	it("converts precise timestamps with an explicit IANA site time zone", () => {
+		const published = new Date("2026-06-15T03:14:03+08:00");
+
+		assert.equal(
+			formatPostDateInTimeZone(published, "Asia/Shanghai"),
+			"2026-06-15",
+		);
+		assert.equal(formatPostDateInTimeZone(published, "UTC"), "2026-06-14");
+		assert.equal(
+			formatPostDateInTimeZone(published, "America/Los_Angeles"),
+			"2026-06-14",
+		);
+
+		assert.deepEqual(getPostDatePartsInTimeZone(published, "Asia/Shanghai"), {
+			year: 2026,
+			month: 6,
+			day: 15,
+			hour: 3,
+			minute: 14,
+			second: 3,
+		});
+	});
+
+	it("does not guess date-only semantics from a UTC-midnight timestamp", () => {
+		const published = new Date("2026-06-15T00:00:00Z");
+
+		assert.equal(
+			formatPostDateInTimeZone(published, "America/New_York", false),
+			"2026-06-14",
+		);
+		assert.equal(
+			formatPostDateInTimeZone(published, "America/New_York", true),
+			"2026-06-15",
+		);
+	});
+
+	it("formats equivalent instants consistently and honors daylight saving time", () => {
+		const offsetTimestamp = new Date("2026-06-15T03:14:03+08:00");
+		const utcTimestamp = new Date("2026-06-14T19:14:03Z");
+
+		assert.equal(offsetTimestamp.getTime(), utcTimestamp.getTime());
+		assert.equal(
+			formatPostDateInTimeZone(offsetTimestamp, "Asia/Shanghai"),
+			formatPostDateInTimeZone(utcTimestamp, "Asia/Shanghai"),
+		);
+
+		assert.deepEqual(
+			getPostDatePartsInTimeZone(
+				new Date("2026-03-29T22:30:00Z"),
+				"Europe/Berlin",
+			),
+			{
+				year: 2026,
+				month: 3,
+				day: 30,
+				hour: 0,
+				minute: 30,
+				second: 0,
+			},
+		);
+	});
+
+	it("uses the site time zone for localized visible dates", () => {
+		const published = new Date("2026-06-15T03:14:03+08:00");
+		assert.equal(
+			formatPostDateWithLocale(published, "en-US", "Asia/Shanghai", {
+				year: "numeric",
+				month: "short",
+				day: "numeric",
+			}),
+			"Jun 15, 2026",
+		);
+	});
+
+	it("rejects invalid dates and unsupported time zones", () => {
+		assert.throws(
+			() => formatPostDateInTimeZone(new Date(Number.NaN), "UTC"),
+			/Invalid published date/,
+		);
+		assert.throws(() => assertValidTimeZone("Mars/Olympus_Mons"), RangeError);
+	});
+});
+
+describe("frontmatter date classification", () => {
+	it("distinguishes date-only scalars from precise timestamps", () => {
+		const frontmatter = `
+published: 2026-06-15 # publish day
+updated: "2026-06-16"
+precise: 2026-06-15T00:00:00Z
+quotedPrecise: '2026-06-15T03:14:03+08:00'
+`;
+
+		assert.equal(getFrontmatterScalar(frontmatter, "published"), "2026-06-15");
+		assert.equal(getFrontmatterScalar(frontmatter, "updated"), "2026-06-16");
+		assert.equal(isDateOnlyFrontmatterField(frontmatter, "published"), true);
+		assert.equal(isDateOnlyFrontmatterField(frontmatter, "updated"), true);
+		assert.equal(isDateOnlyFrontmatterField(frontmatter, "precise"), false);
+		assert.equal(
+			isDateOnlyFrontmatterField(frontmatter, "quotedPrecise"),
+			false,
+		);
+		assert.equal(getFrontmatterScalar(frontmatter, "missing"), undefined);
+	});
+});
+
+describe("published date ordering", () => {
+	it("keeps full timestamp precision for same-day posts", () => {
+		const older = new Date("2026-06-15T09:00:00+08:00");
+		const newer = new Date("2026-06-15T18:00:00+08:00");
+
+		assert.ok(
+			comparePublishedDatesDescending(newer, older, "newer", "older") < 0,
+		);
+		assert.ok(
+			comparePublishedDatesAscending(newer, older, "newer", "older") > 0,
+		);
+	});
+
+	it("uses a deterministic id fallback for identical timestamps", () => {
+		const published = new Date("2026-06-15");
+
+		assert.equal(
+			comparePublishedDatesDescending(published, published, "a-post", "b-post"),
+			-1,
+		);
+		assert.equal(
+			comparePublishedDatesDescending(published, published, "same", "same"),
+			0,
+		);
+		assert.equal(
+			comparePublishedDatesAscending(published, published, "b-post", "a-post"),
+			1,
+		);
+	});
+});


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

Closes #541

## Changes

- 为 SiteConfig 新增独立于界面语言的 IANA timeZone 配置，默认使用 Asia/Shanghai，并同步补充多语言 README 配置示例。
- 在 Content Collection loader 中读取原始 Frontmatter，分别记录 published 与 updated 是否为纯日期，避免将 UTC 零点时间戳误判为纯日期。
- 统一文章卡片、正文元数据、License、Feed 列表、归档、日历 API、permalink、OG 等位置的日期处理：
  - 纯日期保留作者填写的 YYYY-MM-DD，不受构建服务器或访客时区影响；
  - 带时间的值转换到 siteConfig.timeZone 后只显示日期；
  - JSON-LD、Atom 与 HTML datetime 等机器可读字段保留完整 ISO 8601 时间。
- 文章排序继续使用 published 的完整毫秒精度；时间完全相同时使用文章 ID 稳定兜底，保证比较器结果确定。
- 修正 LastModified 将 UTC 时间去掉时区标识后交给浏览器解析的问题，改为传递标准 ISO 时间，使相对更新时间在所有访客时区下表示同一个时间点。
- 增加纯日期、显式偏移、等价时间点、夏令时、无效时区、同日排序及跨访客时区回归测试。

## How To Test

1. 将 siteConfig.timeZone 分别设置为 Asia/Shanghai、UTC、Europe/Berlin 等 IANA 时区。
2. 使用以下 Frontmatter 验证页面日期：
   - published: 2026-06-15 应始终显示 2026-06-15；
   - published: 2026-06-15T03:14:03+08:00 在 Asia/Shanghai 下应显示 2026-06-15；
   - 带时间值切换站点时区后，应显示该时间点在目标站点时区对应的日期。
3. 创建同日但时间不同的文章，确认仍按完整时间排序；时间完全相同时排序稳定。
4. 已执行以下自动化验证：
   - pnpm test：60 项 Node 测试与 8 项加密测试全部通过。
   - pnpm type-check：TypeScript 检查通过。
   - pnpm check：332 个文件，0 errors、0 warnings、0 hints。
   - TZ=UTC pnpm build：成功构建 26 个页面，内容管线、全局样式、Pagefind 和字体检查通过。
   - pnpm exec biome check src/components/features/posts/LastModified.astro tests/layout-regressions.test.mjs：通过。
   - git diff --check：通过。

## Screenshots (if applicable)

不适用

## Additional Notes

- lang 仅控制语言，timeZone 仅控制站点日历时区，两者不自动映射。
- 日记等“几分钟前/几小时前”的相对时长仍按绝对毫秒差计算，不使用站点时区。
- 精确时间不会显示给读者，但会保留用于同日文章排序和机器可读元数据。