### PR TITLE
chore(build): remove content pipeline check

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "update-anime": "node scripts/update-anime.mjs",
     "update-bangumi": "node scripts/update-bangumi.mjs",
     "update-bilibili": "node scripts/update-bilibili.mjs",
-    "build": "node scripts/update-anime.mjs && astro build && node scripts/check-content-pipeline.mjs && node scripts/check-global-style-loading.mjs && pagefind --site dist && node scripts/check-font-loading.mjs",
+    "build": "node scripts/update-anime.mjs && astro build && node scripts/check-global-style-loading.mjs && pagefind --site dist && node scripts/check-font-loading.mjs",
     "submit": "node scripts/indexnow-submit.js",
     "preview": "astro preview",
     "astro": "astro",


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [ ] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings.

## Related Issue

None.

## Changes

Remove `node scripts/check-content-pipeline.mjs` from the production build command. This prevents content-separated builds from failing when the upstream content-pipeline fixture is not present in the personal content repository.

The checker script and its tests are left unchanged; only its automatic build invocation is removed.

## How To Test

Not run, as requested.

## Screenshots (if applicable)

Not applicable.

## Additional Notes

This PR changes only `package.json`.