### PR TITLE
docs: refresh multilingual content authoring guides

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,9 +4,9 @@
 
 [Astro](https://astro.build) で構築された高度な機能と美しいデザインを備えた、モダンで機能が豊富な静的ブログテンプレート。
 
-[![Node.js >= 22](https://img.shields.io/badge/node.js-%3E%3D22-brightgreen)](https://nodejs.org/)
-[![pnpm >= 9](https://img.shields.io/badge/pnpm-%3E%3D9-blue)](https://pnpm.io/)
-[![Astro](https://img.shields.io/badge/Astro-7.0.4-orange)](https://astro.build/)
+[![Node.js >= 20](https://img.shields.io/badge/node.js-%3E%3D20-brightgreen)](https://nodejs.org/)
+[![pnpm >= 11](https://img.shields.io/badge/pnpm-%3E%3D11-blue)](https://pnpm.io/)
+[![Astro](https://img.shields.io/badge/Astro-7.1.3-orange)](https://astro.build/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0.3-blue)](https://www.typescriptlang.org/)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg?logo=apache)](https://opensource.org/licenses/Apache-2.0)
 
@@ -34,43 +34,6 @@
   <tr>
 </table>
 
-## 🚀 NEW: 自動解像度スケーリング
-
-> **🎯 スマート解像度アルゴリズム** - デバイスの解像度に応じてレイアウトをインテリジェントに適応、あらゆるデバイスでの閲覧体験を提供します。
-
-🌏 **README の言語:**
-[**English**](./README.md) /
-[**中文**](./README.zh.md) /
-[**日本語**](./README.ja.md) /
-[**繁體中文**](./README.tw.md) /
-
-### 🔧 コンポーネント構成システムを再構築
-
-- **統合された構成アーキテクチャ:** 全く新しいモジュール型コンポーネント構成システムにより、動的なコンポーネント管理と順序設定に対応
-- **構成駆動型のコンポーネントの読み込み:** サイドバーコンポーネントを再構築し、完全に構成ベースのコンポーネントの読み込みメカニズムを実装しています
-- **統合コントロールの切り替え:** 音楽プレーヤーとお知らせのコンポーネントを独立した有効化切り替えを削除、sidebarLayoutConfig を通じた統合コントロールを実現しています
-- **適応型レスポンシブレイアウト:** コンポーネントはレスポンシブレイアウトに対応しており、デバイスの種類に応じた表示を自動調整します
-
-### 📐 レイアウトシステムを最適化
-
-- **動的なサイドバーの位置調整:** 自動なレイアウト適応による、左右サイドバーの切り替えに対応
-- **インテリジェントな記事ディレクトリの位置付け:** サイドバーが右側にある場合に自動で左側に移動で、より良い読書体験を提供します
-- **グリッドレイアウトの改善:** CSS グリッドレイアウトを最適化でコンテナ幅の異常問題を解決済み
-
-### 🎛️ 構成ファイル形式の標準化
-
-- **標準化された構成形式:** 統一されたコンポーネント設定ファイル形式仕様を作成
-- **型安全性:** 構成の型安全性を確保するための TypeScript 型な定義
-- **拡張性:** カスタムコンポーネントタイプと構成オプションに対応
-
-### 🧹 コードの最適化
-
-- **テストファイルのクリーンアップ:** 未使用なテスト構成と依存関係を削除でプロジェクトのサイズを削減
-- **コード構造の最適化:** コンポーネントアーキテクチャの改善でコードの保守性を向上
-- **パフォーマンスを向上:** コンポーネントの読み込みロジックを最適化し、ページレンダリングパフォーマンスを向上
-
----
-
 ## ✨ 機能
 
 ### 🎨 デザインとインターフェース
@@ -78,36 +41,43 @@
 - [x] [Astro](https://astro.build)と[Tailwind CSS](https://tailwindcss.com)で構築
 - [x] [Swup](https://swup.js.org/)を使用したスムーズなアニメーションとページ遷移
 - [x] システム設定検出機能付きのライト/ダークテーマ切り替え
-- [x] カスタマイズ可能なテーマカラーと動的バナーカルーセル
-- [x] カルーセル、透明度、ぼかし効果を備えた全画面背景画像
+- [x] カスタマイズ可能なテーマカラー、バナーカルーセル、全画面壁紙
+- [x] 壁紙モードの切り替えと透明度・ぼかしの調整
+- [x] サイドバーのコンポーネント、順序、レスポンシブレイアウトを設定可能
+- [x] ワイド画面向けの自動ページスケーリング（オプション）
 - [x] すべてのデバイスに対応した完全レスポンシブデザイン
-- [x] JetBrains Monoフォントによる美しいタイポグラフィ
+- [x] カスタムフォントまたはシステムフォントモード（JetBrains Mono と CJK フォントを含む）
 
 ### 🔍 コンテンツと検索
 
 - [x] [Pagefind](https://pagefind.app/)ベースの高度な検索機能
-- [x] 構文強調表示付きの[拡張Markdown機能](#-markdown拡張機能)
+- [x] 構文強調表示付きの[Markdown と MDX の拡張機能](#-markdown拡張機能)
 - [x] 自動スクロール機能付きのインタラクティブな目次
-- [x] RSSフィード生成
+- [x] 記事ページと同じ Markdown/MDX パイプラインを使った全文 RSS/Atom フィード
 - [x] 読書時間の推定
-- [x] 記事のカテゴリ化とタグシステム
+- [x] 記事のカテゴリ、タグ、ピン留め、エイリアス、カスタムパーマリンク
+- [x] 静的サイト暗号化の限界を明記した、オプションのパスワード保護記事
 
 ### 📱 特別ページ
 
-- [x] **アニメトラッキングページ** - アニメの視聴進捗と評価を追跡
-- [x] **友達ページ** - 友達のウェブサイトを美しいカードで紹介
-- [x] **日記ページ** - ソーシャルメディアのような生活の瞬間を共有
-- [x] **アーカイブページ** - 記事の整理されたタイムラインビュー
-- [x] **アバウトページ** - カスタマイズ可能な自己紹介
+- [x] **アニメページ** - ローカルデータ、Bangumi、Bilibili で視聴状況を管理
+- [x] **フレンドページ** - カードとタグで友人のサイトを紹介
+- [x] **日記ページ** - 文章、画像、場所、気分、タグ付きの記録を共有
+- [x] **アルバムページ** - ローカルまたは外部アルバムを管理し、任意で暗号化
+- [x] **プロジェクト、スキル、デバイス、タイムラインページ** - 構造化されたプロフィールデータを表示
+- [x] **AI ツールページ** - 検索可能なツール一覧を管理
+- [x] **アーカイブと About ページ** - 記事を閲覧し、カスタム紹介を公開
 
 ### 🛠 技術的特徴
 
 - [x] [Expressive Code](https://expressive-code.com/)ベースの**拡張コードブロック**
-- [x] KaTeXレンダリングによる**数式サポート**
-- [x] PhotoSwipeギャラリー統合による**画像最適化**
-- [x] サイトマップとメタタグを含む**SEO最適化**
+- [x] KaTeX、Mermaid、PlantUML による**数式と図表**
+- [x] レスポンシブサイズ、自動グリッド、Fancybox ライトボックスによる**画像拡張**
+- [x] サイトマップ、robots.txt、RSS、Atom、任意の Open Graph 画像を含む**SEO最適化**
 - [x] 遅延読み込みとキャッシュによる**パフォーマンス最適化**
-- [x] Twikoo統合による**コメントシステム**
+- [x] Twikoo または Giscus による**コメントシステム**
+- [x] ローカルと Meting モードに対応した**音楽プレーヤー**
+- [x] Pio による**Live2D マスコット**
 
 ## 🚀 クイックスタート
 
@@ -123,30 +93,34 @@
 2. **依存関係をインストール：**
 
    ```bash
-   # pnpmがインストールされていない場合はインストール
-   npm install -g pnpm
+   # プロジェクトが宣言したパッケージマネージャーを有効化
+   corepack enable
 
    # プロジェクトの依存関係をインストール
    pnpm install
    ```
 
-3. **ブログを設定：**
-   - `src/config.ts`を編集してブログ設定をカスタマイズ
-   - サイト情報、テーマカラー、バナー画像、ソーシャルリンクを更新
-   - 機能ページの機能を設定
+3. **ブログを設定（オプション）：**
+   - ローカルコンテンツだけを使う場合は、ルートの `.env` に `ENABLE_CONTENT_SYNC=false` を設定します。
+   - `src/config/siteConfig.ts` と `src/config/` 内の各モジュールを編集してサイトをカスタマイズします。
+   - 少なくとも `siteURL` をデプロイ先の公開 URL に変更してください。
 
 4. **開発サーバーを起動：**
    ```bash
    pnpm dev
    ```
-   ブログは`http://localhost:4321`で利用可能になります
+   ブログは `http://localhost:3000` で利用可能になります
 
 ### 📝 コンテンツ管理
 
-- **新しい投稿を作成：** `pnpm new-post <ファイル名>`
-- **投稿を編集：** `src/content/posts/`内のファイルを修正
-- **特別ページをカスタマイズ：** `src/content/spec/`内のファイルを編集
-- **画像を追加：** 画像を`src/assets/`または`public/`に配置
+- **投稿を作成：** `pnpm new-post -- <ファイル名>`（`.md` と `.mdx` に対応）
+- **投稿を編集：** `src/content/posts/` 内のファイルを修正します。
+- **About または Friends の内容を編集：** `src/content/spec/` 内の対応するファイルを編集します。
+- **構造化されたページデータを編集：** `src/data/` 内の対応するファイルを編集します。
+- **記事専用画像を追加：** 記事の隣に置き、`./cover.webp` のような相対パスで参照します。
+- **公開画像を追加：** `public/` に置き、`/images/example.webp` のようなルート相対パスで参照します。
+
+> **公開前に確認：** リポジトリにはサンプル記事、ページデータ、アルバム、画像が含まれています。個人サイトをデプロイする前に削除または置き換えてください。
 
 ### 🚀 デプロイ
 
@@ -157,183 +131,160 @@
 - **GitHub Pages：** 付属のGitHub Actionsワークフローを使用
 - **Cloudflare Pages：** リポジトリを接続
 
-デプロイ前に、`src/config.ts`の`siteURL`を更新してください。
+デプロイ前に、`src/config/siteConfig.ts` の `siteURL` を更新してください。
+`.env` や認証情報を Git にコミットしないでください。ホスティング環境では、プロバイダーの環境変数設定を使用します。
 
-- **環境変数設定（オプション）：** `.env.example`を参照して設定してください
-  **推奨されません**`.env`ファイルをGitにコミットすること。`.env`はローカルデバッグまたはビルドのみで使用する必要があります。クラウドプラットフォームにデプロイする場合、プラットフォームの`環境変数`設定経由で設定することをお勧めします。
+`.env.example` には Bilibili のセッションデータや IndexNow の認証情報など、任意の設定も含まれます。必要な場合だけ設定し、ローカル環境またはホスティングプロバイダーの Secret に保存してください。実際の値はコミットしないでください。
 
-## 📝 投稿フロントマター形式
+## 📝 コンテンツの執筆
 
-```yaml
----
-title: 私の最初のブログ投稿
-published: 2023-09-09
-description: これは私の新しいブログの最初の投稿です。
-image: ./cover.jpg
-tags: [タグ1, タグ2]
-category: フロントエンド
-draft: false
-pinned: false
-comment: true
-lang: ja # 記事の言語がconfig.tsのサイト言語と異なる場合のみ設定
----
-```
+記事は `src/content/posts/` 内の `.md` または `.mdx` ファイルで作成します。必須の frontmatter は `title` と `published` だけで、概要、画像、タグ、カテゴリ、下書き、ピン留め、コメント、エイリアス、パーマリンク、帰属情報、ブラウザー側の暗号化を設定できます。
 
-### フロントマターフィールドの説明
+Markdown と MDX は、コールアウト、KaTeX 数式、Expressive Code、Mermaid、PlantUML、GitHub カード、Wiki Link、スポイラー、レスポンシブ画像、画像グリッド、Fancybox、HTML 埋め込みに対応しています。暗号化記事は RSS/Atom から除外されますが、ブラウザー側の暗号化はサーバー側のアクセス制御ではありません。
 
-- **title**: 記事のタイトル（必須）
-- **published**: 公開日（必須）
-- **description**: SEOとプレビュー用の記事の説明
-- **image**: カバー画像のパス（記事ファイルからの相対パス）
-- **tags**: カテゴリ化のためのタグの配列
-- **category**: 記事のカテゴリ
-- **draft**: 本番環境で記事を非表示にするには`true`に設定
-- **pinned**: 記事を上部に固定するには`true`に設定
-- **comment**: 記事のコメントエリアを有効にするには`true`に設定（グローバルコメント機能を有効にする必要があります）
-- **lang**: 記事の言語（サイトのデフォルト言語と異なる場合のみ設定）
+PlantUML はデフォルトで `src/config/markdownConfig.ts` に設定された公開サーバーを使用します。図にパスワード、Token、個人情報を含めないでください。
 
-### ピン留め記事機能
-
-`pinned`フィールドを使用すると、重要な記事をブログリストの上部に固定できます。ピン留めされた記事は、公開日に関係なく、常に通常の記事の前に表示されます。
-
-**使用方法：**
-
-```yaml
-pinned: true  # この記事を上部に固定
-pinned: false # 通常の記事（デフォルト）
-```
-
-**ソートルール：**
-
-1. ピン留め記事が最初に表示され、公開日でソート（最新が先）
-2. 通常の記事がその後に表示され、公開日でソート（最新が先）
-
-### 記事レベルのコメント制御
-
-`comment`フィールドを使用すると、各記事のコメントエリアの有効化と無効化を個別に制御できます。
-
-**使用方法：**
-
-```yaml
-comment: true  # コメントを有効にする（デフォルト）
-comment: false # コメントを無効にする
-```
-
-**注意：**
-この機能を使用するには、まず`src/config.ts`でコメントシステムを有効にする必要があります。
-
-## 🧩 Markdown拡張機能
-
-Mizukiは標準のGitHub Flavored Markdownを超える拡張機能をサポートしています：
-
-### 📝 拡張ライティング
-
-- **コールアウト：** `> [!NOTE]`、`> [!TIP]`、`> [!WARNING]`などを使用して美しい注釈ボックスを作成
-- **数式：** `$インライン$`と`$$ブロック$$`構文を使用してLaTeX数式を記述
-- **コード強調表示：** 行番号とコピーボタン付きの高度な構文強調表示
-- **GitHubカード：** `::github{repo="ユーザー/リポジトリ"}`を使用してリポジトリカードを埋め込み
-
-### 🎨 ビジュアル要素
-
-- **画像ギャラリー：** 画像表示のための自動PhotoSwipe統合
-- **折りたたみセクション：** 展開可能なコンテンツブロックを作成
-- **カスタムコンポーネント：** 特別なディレクティブでコンテンツを強化
-
-### 📊 コンテンツ整理
-
-- **目次：** 見出しから自動生成され、スムーズスクロールをサポート
-- **読書時間：** 自動計算して表示
-- **記事メタデータ：** カテゴリとタグを含む豊富なフロントマターサポート
+frontmatter の全フィールド、記法、画像ルール、図表、動画埋め込み、暗号化の制限、公開前チェックリストは[コンテンツ執筆ガイド](docs/CONTENT_AUTHORING.ja.md)を参照してください。
 
 ## ⚡ コマンド
 
 すべてのコマンドはプロジェクトルートから実行します：
 
-| コマンド                     | アクション                                   |
-| :--------------------------- | :------------------------------------------- |
-| `pnpm install`               | 依存関係をインストール                       |
-| `pnpm dev`                   | `localhost:4321`でローカル開発サーバーを起動 |
-| `pnpm build`                 | 本番サイトを`./dist/`にビルド                |
-| `pnpm preview`               | デプロイ前にビルドをローカルでプレビュー     |
-| `pnpm check`                 | Astroエラーチェックを実行                    |
-| `pnpm format`                | Prettierでコードをフォーマット               |
-| `pnpm lint`                  | コードの問題をチェックして修正               |
-| `pnpm new-post <ファイル名>` | 新しいブログ投稿を作成                       |
-| `pnpm astro ...`             | Astro CLIコマンドを実行                      |
+| コマンド | アクション |
+| :--- | :--- |
+| `pnpm install` | 依存関係をインストール。 |
+| `pnpm dev` | `http://localhost:3000` で開発サーバーを起動。 |
+| `pnpm build` | `./dist/` をビルドし、検索データとビルドチェックを実行。 |
+| `pnpm preview` | 本番ビルドをローカルでプレビュー。 |
+| `pnpm run check` | Astro の診断を実行。 |
+| `pnpm run type-check` | TypeScript の型チェックを実行。 |
+| `pnpm test` | Markdown、レイアウト、画像、音楽、暗号化テストを実行。 |
+| `pnpm run format` | Biome でソースをフォーマット。 |
+| `pnpm run lint` | Biome でチェックと自動修正。 |
+| `pnpm new-post -- <ファイル名>` | Markdown または MDX の記事を作成。 |
+| `pnpm run sync-content` | 任意の外部コンテンツリポジトリを同期。 |
+| `pnpm run init-content` | 外部コンテンツ同期を対話形式で初期化。 |
+| `pnpm astro ...` | Astro CLI コマンドを実行。 |
 
 ## 🎯 設定ガイド
 
 ### 🔧 基本設定
 
-`src/config.ts`を編集してブログをカスタマイズ：
+設定は `src/config/` 以下のモジュールに分割され、`src/config/index.ts` が共通のエクスポート入口です。主要設定は `src/config/siteConfig.ts` にあります：
 
 ```typescript
 export const siteConfig: SiteConfig = {
   title: "あなたのブログ名",
   subtitle: "あなたのブログの説明",
-  lang: "ja", // または "zh-CN"、"en" など
-  timeZone: "Asia/Shanghai", // IANAタイムゾーン（例：Asia/Tokyo、Europe/Berlin）
+  siteURL: "https://example.com/", // 末尾のスラッシュを維持
+  lang: "ja", // 例: "en"、"zh_CN"、"zh_TW"
+  timeZone: "Asia/Tokyo", // 有効な IANA タイムゾーン
   themeColor: {
-    hue: 210, // 0-360、テーマの色相
-    fixed: false, // テーマカラーピッカーを非表示
+    hue: 210, // 0–360
+    fixed: false, // true で訪問者のテーマカラー選択を非表示
   },
-  banner: {
-    enable: true,
-    src: ["assets/banner/1.webp"], // バナー画像
-    carousel: {
-      enable: true,
-      interval: 0.8, // 秒
-    },
+  featurePages: {
+    anime: true,
+    diary: true,
+    friends: true,
+    projects: true,
+    skills: true,
+    timeline: true,
+    albums: true,
+    devices: true,
+    aiTools: true,
   },
+  // 残りのフィールドはテンプレートのデフォルトを維持してください。
 };
 ```
 
-### 📱 機能ページの設定
+その他の主な設定ファイル：
 
-- **アニメページ：** `src/pages/anime.astro`でアニメリストを編集
-- **友達ページ：** `src/content/spec/friends.md`で友達データを編集
-- **日記ページ：** `src/pages/diary.astro`で瞬間を編集
-- **アバウトページ：** `src/content/spec/about.md`でコンテンツを編集
+- `src/config/navBarConfig.ts` — ナビゲーションとメニュー。
+- `src/config/profileConfig.ts` — アバター、名前、プロフィール、ソーシャルリンク。
+- `src/config/sidebarConfig.ts` — サイドバーのウィジェット、順序、位置、レスポンシブ動作。
+- `src/config/backgroundWallpaper.ts` と `src/config/effectsConfig.ts` — 壁紙と視覚効果。
+- `src/config/commentConfig.ts` — Twikoo または Giscus のグローバル設定。コメントはデフォルトで無効です。使用前に `enable: true` とプロバイダー設定を追加してください。
+- `src/config/musicConfig.ts` — 音楽プレーヤーのモードとプレイリスト。
+- `src/config/markdownConfig.ts` — Wiki Link、自動画像グリッド、PlantUML。
+- `src/config/permalinkConfig.ts` — 任意のグローバルパーマリンク形式。
+- `src/config/expressiveCodeConfig.ts` — コードブロックのテーマと動作。
+
+### 📱 機能ページのコンテンツ
+
+ページの有効化は `siteConfig.featurePages` で制御します。ページの内容はテンプレートから分離されています：
+
+| ページ | コンテンツまたはデータ |
+| :--- | :--- |
+| About | `src/content/spec/about.md` |
+| Friends | `src/content/spec/friends.md` と `src/data/friends.ts` |
+| Anime | `src/config/siteConfig.ts` でソースモードを設定、ローカルデータは `src/data/anime.ts` |
+| Diary | `src/data/diary.ts`、または `diaryApiUrl` の Memos エンドポイント |
+| Albums | `public/images/albums/`、各ローカルアルバムは `info.json` を使用 |
+| Projects | `src/data/projects.ts` |
+| Skills | `src/data/skills.ts` |
+| Devices | `src/data/devices.ts` |
+| Timeline | `src/data/timeline.ts` |
+| AI Tools | `src/data/ai-tools.ts` |
+
+ページの内容を変更するためだけに `src/pages/*.astro` を編集しないでください。これらはレイアウトとレンダリングを定義します。
 
 ### 📦 コードとコンテンツの分離（オプション）
 
-Mizukiは、コードとコンテンツを2つの独立したリポジトリに分けて管理することをサポートしており、チーム协作や大規模プロジェクトに適しています。
+Mizuki はテーマコードとブログコンテンツを別のリポジトリに分離できます。プライベートコンテンツ、独立したバージョン管理、チーム協業に便利ですが、必須ではありません。
 
 **簡単選択**:
 
-| 使用シナリオ                        | 設定方法                         | 対象者                             |
-| ----------------------------------- | -------------------------------- | ---------------------------------- |
-| 🆕 **ローカルモード**（デフォルト） | 設定不要、そのまま使用           | 初心者、個人ブログ                 |
-| 🔧 **分離モード**                   | `ENABLE_CONTENT_SYNC=true`を設定 | チーム协作、プライベートコンテンツ |
+| 用途 | 設定 | コンテンツの場所 |
+| :--- | :--- | :--- |
+| **ローカルコンテンツ** | `ENABLE_CONTENT_SYNC=false` | `src/content/`、`src/data/`、`public/images/` |
+| **外部コンテンツリポジトリ** | `ENABLE_CONTENT_SYNC=true` と `CONTENT_REPO_URL=...` | 上記のパスへ同期される別リポジトリ |
 
 **ワンクリック有効化/無効化**:
 
 ```bash
-# 方法 1: ローカルモード（初心者向け）
-# .envファイルを作成せず、そのまま実行
+# ローカルコンテンツモード（入門向け）
+# .env に設定して同期を明示的に無効化
+ENABLE_CONTENT_SYNC=false
 pnpm dev
 
-# 方法 2: コンテンツ分離モード
-# 1. 設定ファイルをコピー
+# 外部コンテンツリポジトリモード
+# 1. 設定例をコピー
 cp .env.example .env
 
-# 2. .envを編集してコンテンツ分離を有効化
+# 2. .env を編集
 ENABLE_CONTENT_SYNC=true
 CONTENT_REPO_URL=https://github.com/your-username/Mizuki-Content.git
+# CONTENT_DIR=./content  # 任意。デフォルトもこのパスです
 
-# 3. コンテンツを同期
+# 3. コンテンツを同期してサイトを起動
 pnpm run sync-content
+pnpm dev
 ```
 
-**機能**:
+外部コンテンツリポジトリは次の構成にできます：
 
-- ✅ パブリックおよびプライベートリポジトリをサポート 🔐
-- ✅ ワンクリックで有効化/無効化、コード修正不要
-- ✅ 自動同期、開発前に最新コンテンツを自動プル
+```text
+Mizuki-Content/
+├── posts/       # .md と .mdx の記事
+├── spec/        # About、Friends などの Markdown ページ
+├── data/        # プロジェクトやスキルなどの構造化データ
+└── images/      # アルバムや記事を含む公開画像
+```
 
-📖 **詳細設定**: [コンテンツ分離完全ガイド](docs/CONTENT_SEPARATION.md)
-🔄 **移行チュートリアル**: [シングルリポジトリから分離モードへ移行](docs/MIGRATION_GUIDE.md)
-📚 **その他のドキュメント**: [ドキュメントインデックス](docs/README.md)
+同期スクリプトはこれらを `src/content/posts/`、`src/content/spec/`、`src/data/`、`public/images/` にマッピングします。`src/data/ai-tools.ts` はコードリポジトリ側で管理され、同期時も保護されます。
+
+> **同期に関する警告：** `ENABLE_CONTENT_SYNC` を有効にすると、`pnpm dev` と `pnpm build` の前に同期フックが実行されます。`CONTENT_DIR` が Git リポジトリの場合、スクリプトはリモートの `main` または `master` を fetch して reset します。既存のランタイムディレクトリを `.backup` に移動し、ジャンクションまたはコピーを作成し、コードリポジトリに同期結果をコミットする場合もあります。実行前にローカルの変更をコミットまたはバックアップし、同期先を直接編集しないでください。
+
+プライベートリポジトリには SSH URL を使うか、デプロイプロバイダーで認証情報を設定してください。Token を `.env` に書いてコミットしたり、公開 URL に含めたりしないでください。
+
+📖 **詳細設定：** [コンテンツ分離完全ガイド](docs/CONTENT_SEPARATION.md)
+
+🔄 **移行チュートリアル：** [シングルリポジトリから分離モードへ移行](docs/MIGRATION_GUIDE.md)
+
+🚀 **デプロイガイド：** [デプロイガイド](docs/DEPLOYMENT.md)
+
+📚 **その他のドキュメント：** [ドキュメントインデックス](docs/README.md)
 
 ## ✏️ 貢献
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 A modern, feature-rich static blog template built with [Astro](https://astro.build), featuring advanced functionality and beautiful design.
 
-[![Node.js >= 22](https://img.shields.io/badge/node.js-%3E%3D22-brightgreen)](https://nodejs.org/)
-[![pnpm >= 9](https://img.shields.io/badge/pnpm-%3E%3D9-blue)](https://pnpm.io/)
-[![Astro](https://img.shields.io/badge/Astro-7.0.4-orange)](https://astro.build/)
+[![Node.js >= 20](https://img.shields.io/badge/node.js-%3E%3D20-brightgreen)](https://nodejs.org/)
+[![pnpm >= 11](https://img.shields.io/badge/pnpm-%3E%3D11-blue)](https://pnpm.io/)
+[![Astro](https://img.shields.io/badge/Astro-7.1.3-orange)](https://astro.build/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0.3-blue)](https://www.typescriptlang.org/)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg?logo=apache)](https://opensource.org/licenses/Apache-2.0)
 
@@ -34,43 +34,6 @@ Get started quickly with our comprehensive documentation. Whether you're customi
   <tr>
 </table>
 
-## 🚀 NEW: Automatic Resolution Adaptation
-
-> **🎯 Automatic Resolution Algorithm** - Intelligently adapts content layout based on device screen resolution, providing the best viewing experience for all devices
-
-🌏 README Language
-[**English**](./README.md) /
-[**中文**](./README.zh.md) /
-[**日本語**](./README.ja.md) /
-[**繁體中文**](./README.tw.md) /
-
-### 🔧 Component Configuration System Restructuring
-
-- **Unified Configuration Architecture:** Brand new modular component configuration system, supporting dynamic component management and order configuration
-- **Configuration-Driven Component Loading:** Restructured SideBar component, implementing fully configuration-based component loading mechanism
-- **Unified Control Switches:** Removed independent enable switches for music player and announcement components, unified control through sidebarLayoutConfig
-- **Responsive Layout Adaptation:** Components support responsive layouts, automatically adjusting display based on device type
-
-### 📐 Layout System Optimization
-
-- **Dynamic Sidebar Position Adjustment:** Support for left/right sidebar switching, with automatic layout adaptation
-- **Intelligent Article Directory Positioning:** When sidebar is on the right, article navigation automatically moves to the left, providing a better reading experience
-- **Grid Layout Improvements:** Optimized CSS Grid layout, resolving container width anomaly issues
-
-### 🎛️ Configuration File Format Standardization
-
-- **Standardized Configuration Format:** Created unified component configuration file format specifications
-- **Type Safety:** Comprehensive TypeScript type definitions ensuring configuration type safety
-- **Extensibility:** Support for custom component types and configuration options
-
-### 🧹 Code Optimization
-
-- **Test File Cleanup:** Removed unused test configurations and dependencies, reducing project size
-- **Code Structure Optimization:** Improved component architecture, enhancing code maintainability
-- **Performance Improvement:** Optimized component loading logic, improving page rendering performance
-
----
-
 ## ✨ Features
 
 ### 🎨 Design & Interface
@@ -78,36 +41,43 @@ Get started quickly with our comprehensive documentation. Whether you're customi
 - [x] Built with [Astro](https://astro.build) and [Tailwind CSS](https://tailwindcss.com)
 - [x] Smooth animations and page transitions using [Swup](https://swup.js.org/)
 - [x] Light/dark theme switching with system preference detection
-- [x] Customizable theme colors and dynamic banner carousel
-- [x] Fullscreen background images with carousel, opacity, and blur effects
+- [x] Customizable theme colors, banner carousel, and fullscreen wallpapers
+- [x] Switchable wallpaper modes with opacity and blur controls
+- [x] Configurable sidebar components, ordering, and responsive layouts
+- [x] Optional automatic page scaling for wide screens
 - [x] Fully responsive design for all devices
-- [x] Beautiful typography with JetBrains Mono font
+- [x] Custom or system font modes, including JetBrains Mono and CJK fonts
 
 ### 🔍 Content & Search
 
 - [x] Advanced search functionality based on [Pagefind](https://pagefind.app/)
-- [x] [Enhanced Markdown features](#-markdown-extensions) with syntax highlighting
+- [x] [Markdown and MDX extensions](#-markdown-extensions) with syntax highlighting
 - [x] Interactive table of contents with auto-scrolling
 - [x] Full-content RSS and Atom feeds using the same Markdown/MDX pipeline as article pages
 - [x] Reading time estimation
-- [x] Article categorization and tagging system
+- [x] Article categorization, tagging, pinning, aliases, and custom permalinks
+- [x] Optional password-protected posts with a documented static-site security boundary
 
 ### 📱 Special Pages
 
-- [x] **Anime Tracking Page** - Track anime watching progress and ratings
-- [x] **Friends Page** - Beautiful cards showcasing friend websites
-- [x] **Diary Page** - Share life moments, similar to social media
-- [x] **Archive Page** - Organized timeline view of articles
-- [x] **About Page** - Customizable personal introduction
+- [x] **Anime Page** - Track anime watching progress using local data, Bangumi, or Bilibili sources
+- [x] **Friends Page** - Showcase friend websites with cards and tags
+- [x] **Diary Page** - Share moments with text, images, locations, moods, and tags
+- [x] **Albums Page** - Organize local or external photo albums with optional encryption
+- [x] **Projects, Skills, Devices, and Timeline Pages** - Showcase structured personal data
+- [x] **AI Tools Page** - Maintain a searchable catalog of tools
+- [x] **Archive and About Pages** - Browse posts or publish a custom introduction
 
 ### 🛠 Technical Features
 
 - [x] **Enhanced code blocks** based on [Expressive Code](https://expressive-code.com/)
-- [x] **Math formula support** with KaTeX rendering
-- [x] **Image optimization** with PhotoSwipe gallery integration
-- [x] **SEO optimization** including sitemaps and meta tags
+- [x] **Math formulas** with KaTeX, plus Mermaid and PlantUML diagrams
+- [x] **Image enhancements** including responsive sizing, automatic grids, and Fancybox lightboxes
+- [x] **SEO optimization** including sitemap, robots.txt, RSS, Atom, and optional Open Graph images
 - [x] **Performance optimization** with lazy loading and caching
-- [x] **Comment system** with Twikoo integration
+- [x] **Comment system** with Twikoo or Giscus integration
+- [x] **Music player** with local and Meting modes
+- [x] **Live2D mascot** support through Pio
 
 ## 🚀 Quick Start
 
@@ -123,30 +93,34 @@ Get started quickly with our comprehensive documentation. Whether you're customi
 2. **Install dependencies:**
 
    ```bash
-   # Install pnpm if not already installed
-   npm install -g pnpm
+   # Enable the package manager version declared by the project
+   corepack enable
 
    # Install project dependencies
    pnpm install
    ```
 
-3. **Configure your blog:**
-   - Edit `src/config.ts` to customize blog settings
-   - Update site information, theme colors, banner images, and social links
-   - Configure feature page functionality
+3. **Configure your blog (optional):**
+   - Set `ENABLE_CONTENT_SYNC=false` in a root `.env` file if you want to use only local content.
+   - Edit `src/config/siteConfig.ts` and the other modules in `src/config/` to customize the site.
+   - At minimum, replace `siteURL` with the public URL of your deployment.
 
 4. **Start the development server:**
    ```bash
    pnpm dev
    ```
-   Your blog will be available at `http://localhost:4321`
+   Your blog will be available at `http://localhost:3000`
 
 ### 📝 Content Management
 
-- **Create new posts:** `pnpm new-post <filename>`
-- **Edit posts:** Modify files in `src/content/posts/`
-- **Customize special pages:** Edit files in `src/content/spec/`
-- **Add images:** Place images in `src/assets/` or `public/`
+- **Create a post:** `pnpm new-post -- <filename>`; both `.md` and `.mdx` are supported.
+- **Edit posts:** Modify files in `src/content/posts/`.
+- **Edit About or Friends page content:** Modify the corresponding files in `src/content/spec/`.
+- **Edit structured page data:** Modify the relevant files in `src/data/`.
+- **Add article-local images:** Keep them next to the post and reference them with a relative path such as `./cover.webp`.
+- **Add public images:** Place them under `public/` and reference them with a root-relative path such as `/images/example.webp`.
+
+> **Before publishing:** This repository includes demo posts, page data, albums, and images. Remove or replace the sample content before deploying your own site.
 
 ### 🚀 Deployment
 
@@ -159,181 +133,163 @@ Deploy your blog to any static hosting platform:
 
 - **Environment Variable Configuration (Optional):** Refer to `.env.example` for configuration
 
-Before deployment, update the `siteURL` in `src/config.ts`.
-**Not recommended** to commit the `.env` file to Git. The `.env` file should only be used for local debugging or building. For cloud platform deployment, it's recommended to configure via the platform's `environment variables` settings.
+Before deployment, update `siteURL` in `src/config/siteConfig.ts`. Do not commit `.env` or credentials to Git. For hosted builds, configure environment variables in the hosting provider instead.
 
-## 📝 Post Frontmatter Format
+The optional `.env.example` settings include Bilibili session data and IndexNow credentials. Only configure them when needed, keep them in local or hosting-provider secrets, and never commit real values.
 
-```yaml
----
-title: My First Blog Post
-published: 2023-09-09
-description: This is the first post of my new blog.
-image: ./cover.jpg
-tags: [tag1, tag2]
-category: Frontend
-draft: false
-pinned: false
-comment: true
-lang: en # Only set when article language differs from site language in config.ts
----
-```
+## 📝 Writing Content
 
-### Frontmatter Field Descriptions
+Posts use `.md` or `.mdx` files under `src/content/posts/`. The only required frontmatter fields are `title` and `published`; optional fields cover summaries, images, tags, categories, drafts, pinning, comments, aliases, permalinks, attribution, and browser-side encryption.
 
-- **title**: Article title (required)
-- **published**: Publication date (required)
-- **description**: Article description for SEO and previews
-- **image**: Cover image path (relative to article file)
-- **tags**: Array of tags for categorization
-- **category**: Article category
-- **draft**: Set to `true` to hide article in production
-- **pinned**: Set to `true` to pin article to top
-- **comment**: Set to `true` to enable article comment area (requires global comment function enabled)
-- **lang**: Article language (only set when different from site default)
+Markdown and MDX support callouts, KaTeX math, Expressive Code, Mermaid, PlantUML, GitHub cards, Wiki Links, spoilers, responsive images, image grids, lightboxes, and HTML embeds. Encrypted posts are excluded from RSS and Atom, but browser-side encryption is not server-side access control.
 
-### Pinned Articles Feature
-
-The `pinned` field allows you to pin important articles to the top of your blog list. Pinned articles will always appear before regular articles regardless of their publication date.
-
-**Usage:**
-
-```yaml
-pinned: true  # Pin this article to the top
-pinned: false # Regular article (default)
-```
-
-**Sorting Rules:**
-
-1. Pinned articles appear first, sorted by publication date (newest first)
-2. Regular articles follow, sorted by publication date (newest first)
-
-### Article-Level Comment Control
-
-The `comment` field allows you to individually control the enabling and disabling of the comment area for each article.
-
-**Usage:**
-
-```yaml
-comment: true  # Enable comments (default)
-comment: false # Disable comments
-```
-
-**Note:**
-This feature requires the comment system to be enabled in `src/config.ts` first.
+See the complete [Content Authoring Guide](docs/CONTENT_AUTHORING.md) for the frontmatter schema, writing syntax, image rules, diagrams, video embeds, encryption limits, and publishing checklist.
 
 ## 🧩 Markdown Extensions
 
-Mizuki supports enhanced features beyond standard GitHub Flavored Markdown:
+Mizuki uses one Markdown/MDX pipeline for article pages, RSS, and Atom. It supports callouts, math, enhanced code blocks, Mermaid, PlantUML, GitHub cards, Wiki Links, spoilers, responsive images, image grids, Fancybox lightboxes, and HTML embeds.
 
-### 📝 Enhanced Writing
-
-- **Callouts:** Create beautiful annotation boxes using `> [!NOTE]`, `> [!TIP]`, `> [!WARNING]`, etc.
-- **Math Formulas:** Write LaTeX math formulas using `$inline$` and `$$block$$` syntax
-- **Code Highlighting:** Advanced syntax highlighting with line numbers and copy buttons
-- **GitHub Cards:** Embed repository cards using `::github{repo="user/repo"}`
-
-### 🎨 Visual Elements
-
-- **Image Gallery:** Automatic PhotoSwipe integration for image viewing
-- **Collapsible Sections:** Create expandable content blocks
-- **Custom Components:** Enhance content with special directives
-
-### 📊 Content Organization
-
-- **Table of Contents:** Automatically generated from headings with smooth scrolling
-- **Reading Time:** Automatically calculated and displayed
-- **Article Metadata:** Rich frontmatter support with categories and tags
+For syntax and examples, see the [Content Authoring Guide](docs/CONTENT_AUTHORING.md). PlantUML uses the public server configured in `src/config/markdownConfig.ts` by default, so diagrams must not contain secrets or private data.
 
 ## ⚡ Commands
 
-All commands are run from the project root:
+Run commands from the project root:
 
-| Command                    | Action                                     |
-| :------------------------- | :----------------------------------------- |
-| `pnpm install`             | Install dependencies                       |
-| `pnpm dev`                 | Start local dev server at `localhost:4321` |
-| `pnpm build`               | Build production site to `./dist/`         |
-| `pnpm preview`             | Preview build locally before deployment    |
-| `pnpm check`               | Run Astro error checking                   |
-| `pnpm format`              | Format code with Prettier                  |
-| `pnpm lint`                | Check and fix code issues                  |
-| `pnpm new-post <filename>` | Create a new blog post                     |
-| `pnpm astro ...`           | Run Astro CLI commands                     |
+| Command | Action |
+| :--- | :--- |
+| `pnpm install` | Install dependencies. |
+| `pnpm dev` | Start the development server at `http://localhost:3000`. |
+| `pnpm build` | Build the production site in `./dist/`, generate search data, and run build checks. |
+| `pnpm preview` | Preview the production build locally. |
+| `pnpm run check` | Run Astro diagnostics. |
+| `pnpm run type-check` | Run TypeScript without emitting files. |
+| `pnpm test` | Run the Markdown, layout, image, music, and crypto tests. |
+| `pnpm run format` | Format source files with Biome. |
+| `pnpm run lint` | Check and automatically fix source files with Biome. |
+| `pnpm new-post -- <filename>` | Create a new Markdown or MDX post. |
+| `pnpm run sync-content` | Synchronize an optional external content repository. |
+| `pnpm run init-content` | Interactively initialize external content synchronization. |
+| `pnpm astro ...` | Run an Astro CLI command. |
 
 ## 🎯 Configuration Guide
 
 ### 🔧 Basic Configuration
 
-Edit `src/config/siteConfig.ts` to customize your blog:
+Configuration is split into focused modules under `src/config/`; `src/config/index.ts` is the shared export entry point. The main site settings live in `src/config/siteConfig.ts`:
 
 ```typescript
 export const siteConfig: SiteConfig = {
   title: "Your Blog Name",
   subtitle: "Your Blog Description",
-  lang: "en", // or "zh-CN", "ja", etc.
-  timeZone: "Asia/Shanghai", // IANA time zone, e.g. Asia/Tokyo or Europe/Berlin
+  siteURL: "https://example.com/", // Keep the trailing slash
+  lang: "en", // e.g. "zh_CN", "ja", or "zh_TW"
+  timeZone: "Europe/London", // Any valid IANA time zone
   themeColor: {
-    hue: 210, // 0-360, theme hue
-    fixed: false, // Hide theme color picker
+    hue: 210, // 0–360
+    fixed: false, // Hide the visitor theme-color picker when true
   },
-  banner: {
-    enable: true,
-    src: ["assets/banner/1.webp"], // Banner images
-    carousel: {
-      enable: true,
-      interval: 0.8, // seconds
-    },
+  featurePages: {
+    anime: true,
+    diary: true,
+    friends: true,
+    projects: true,
+    skills: true,
+    timeline: true,
+    albums: true,
+    devices: true,
+    aiTools: true,
   },
+  // Keep the remaining fields from the template defaults.
 };
 ```
 
-### 📱 Feature Page Configuration
+Other commonly used configuration files include:
 
-- **Anime Page:** Edit anime list in `src/pages/anime.astro`
-- **Friends Page:** Edit friend data in `src/content/spec/friends.md`
-- **Diary Page:** Edit moments in `src/pages/diary.astro`
-- **About Page:** Edit content in `src/content/spec/about.md`
+- `src/config/navBarConfig.ts` — navigation links and menus.
+- `src/config/profileConfig.ts` — avatar, name, bio, and social links.
+- `src/config/sidebarConfig.ts` — sidebar widgets, order, positions, and responsive behavior.
+- `src/config/backgroundWallpaper.ts` and `src/config/effectsConfig.ts` — wallpaper and visual effects.
+- `src/config/commentConfig.ts` — global Twikoo or Giscus settings. Comments are disabled by default; set `enable: true` and configure the selected provider before using them.
+- `src/config/musicConfig.ts` — music player mode and playlist source.
+- `src/config/markdownConfig.ts` — Wiki Links, automatic image grids, and PlantUML.
+- `src/config/permalinkConfig.ts` — optional global permalink format.
+- `src/config/expressiveCodeConfig.ts` — code block themes and behavior.
+
+### 📱 Feature Page Content
+
+The page switches are controlled by `siteConfig.featurePages`. Page content and data are kept separate from page templates:
+
+| Page | Content or data source |
+| :--- | :--- |
+| About | `src/content/spec/about.md` |
+| Friends | `src/content/spec/friends.md` and `src/data/friends.ts` |
+| Anime | `src/config/siteConfig.ts` for the source mode; `src/data/anime.ts` for local data |
+| Diary | `src/data/diary.ts`, or a Memos endpoint configured by `diaryApiUrl` |
+| Albums | `public/images/albums/`; each local album uses an `info.json` file |
+| Projects | `src/data/projects.ts` |
+| Skills | `src/data/skills.ts` |
+| Devices | `src/data/devices.ts` |
+| Timeline | `src/data/timeline.ts` |
+| AI Tools | `src/data/ai-tools.ts` |
+
+Avoid editing `src/pages/*.astro` just to change page content; those files define the layout and rendering behavior.
 
 ### 📦 Code-Content Separation (Optional)
 
-Mizuki supports separating code and content into two independent repositories, suitable for team collaboration and large projects.
+Mizuki can separate theme code from blog content into two repositories. This is useful for private content, independent content versioning, or collaboration, but it is optional.
 
 **Quick Selection**:
 
-| Use Case                    | Configuration                  | For Whom                            |
-| --------------------------- | ------------------------------ | ----------------------------------- |
-| 🆕 **Local Mode** (default) | No configuration, use directly | Beginners, personal blogs           |
-| 🔧 **Separation Mode**      | Set `ENABLE_CONTENT_SYNC=true` | Team collaboration, private content |
+| Use case | Configuration | Content location |
+| :--- | :--- | :--- |
+| **Local content** | `ENABLE_CONTENT_SYNC=false` | `src/content/`, `src/data/`, and `public/images/` |
+| **External content repository** | `ENABLE_CONTENT_SYNC=true` and `CONTENT_REPO_URL=...` | A separate repository synchronized into the paths above |
 
 **One-Click Enable/Disable**:
 
 ```bash
-# Method 1: Local Mode (recommended for beginners)
-# No need to create .env file, run directly
+# Local content mode (recommended for getting started)
+# Put this in .env to disable synchronization explicitly.
+ENABLE_CONTENT_SYNC=false
 pnpm dev
 
-# Method 2: Content Separation Mode
-# 1. Copy configuration file
+# External content repository mode
+# 1. Copy the example configuration
 cp .env.example .env
 
-# 2. Edit .env to enable content separation
+# 2. Edit .env
 ENABLE_CONTENT_SYNC=true
 CONTENT_REPO_URL=https://github.com/your-username/Mizuki-Content.git
+# CONTENT_DIR=./content  # Optional; this is the default
 
-# 3. Sync content
+# 3. Synchronize content and start the site
 pnpm run sync-content
+pnpm dev
 ```
 
-**Features**:
+An external repository uses this structure:
 
-- ✅ Supports public and private repositories 🔐
-- ✅ One-click enable/disable without code modification
-- ✅ Auto-sync, pulls latest content automatically before development
+```text
+Mizuki-Content/
+├── posts/       # .md and .mdx posts
+├── spec/        # About, Friends, and other Markdown page content
+├── data/        # Structured page data such as projects or skills
+└── images/      # Public images, including albums and post assets
+```
 
-📖 **Detailed Configuration**: [Content Separation Guide](docs/CONTENT_SEPARATION.md)
-🔄 **Migration Tutorial**: [Migrate from Single Repo to Separation Mode](docs/MIGRATION_GUIDE.md)
-📚 **More Documentation**: [Documentation Index](docs/README.md)
+The sync script maps these directories to `src/content/posts/`, `src/content/spec/`, `src/data/`, and `public/images/`. `src/data/ai-tools.ts` is owned by the code repository and is preserved during synchronization.
+
+> **Sync warning:** When `ENABLE_CONTENT_SYNC` is enabled, `pnpm dev` and `pnpm build` run the sync hook automatically. If `CONTENT_DIR` already contains a Git repository, the script fetches and resets it to its `main` or `master` remote branch. It can also back up existing runtime directories as `.backup`, create junctions or copies, and commit synchronized changes in the code repository. Commit or back up local content changes before running it, and do not edit synchronized target files directly.
+
+For private repositories, use an SSH URL or configure credentials through the deployment platform. Never commit tokens in `.env` or put them in a public repository URL.
+
+📖 **Detailed Configuration:** [Content Separation Guide](docs/CONTENT_SEPARATION.md)
+
+🔄 **Migration Tutorial:** [Migrate from Single Repo to Separation Mode](docs/MIGRATION_GUIDE.md)
+
+🚀 **Deployment Guide:** [Deployment Guide](docs/DEPLOYMENT.md)
+
+📚 **Documentation Index:** [Documentation Index](docs/README.md)
 
 ## ✏️ Contributing
 

--- a/README.tw.md
+++ b/README.tw.md
@@ -4,9 +4,9 @@
 
 一個現代化、功能豐富的靜態部落格模板，基於 [Astro](https://astro.build) 構建，具有先進的功能和精美的設計。
 
-[![Node.js >= 22](https://img.shields.io/badge/node.js-%3E%3D22-brightgreen)](https://nodejs.org/)
-[![pnpm >= 9](https://img.shields.io/badge/pnpm-%3E%3D9-blue)](https://pnpm.io/)
-[![Astro](https://img.shields.io/badge/Astro-7.0.4-orange)](https://astro.build/)
+[![Node.js >= 20](https://img.shields.io/badge/node.js-%3E%3D20-brightgreen)](https://nodejs.org/)
+[![pnpm >= 11](https://img.shields.io/badge/pnpm-%3E%3D11-blue)](https://pnpm.io/)
+[![Astro](https://img.shields.io/badge/Astro-7.1.3-orange)](https://astro.build/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0.3-blue)](https://www.typescriptlang.org/)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg?logo=apache)](https://opensource.org/licenses/Apache-2.0)
 
@@ -34,43 +34,6 @@
   <tr>
 </table>
 
-## 🚀 NEW: 自動解析度適配
-
-> **🎯 自動解析度演算法** - 智能適配內容佈局基於裝置螢幕解析度，為所有裝置提供最佳觀看體驗
-
-🌏 README 語言
-[**English**](./README.md) /
-[**中文**](./README.zh.md) /
-[**日本語**](./README.ja.md) /
-[**繁體中文**](./README.tw.md) /
-
-### 🔧 元件配置系統重構
-
-- **統一配置架構：** 全新的模組化元件配置體系，支援動態元件管理和順序配置
-- **配置驅動的元件載入：** 重構 SideBar 元件，實現完全基於配置的元件載入機制
-- **統一控制開關：** 移除音樂播放器和公告元件的獨立 enable 開關，統一由 sidebarLayoutConfig 控制
-- **響應式佈局適配：** 元件支援響應式佈局，可根據裝置類型自動調整顯示
-
-### 📐 佈局系統優化
-
-- **側邊欄位置動態調整：** 支援左右側邊欄切換，佈局自動適配
-- **文章目錄智能定位：** 當側邊欄在右側時，文章導航自動移至左側，提供更好的閱讀體驗
-- **網格佈局改進：** 優化 CSS Grid 佈局，解決容器寬度異常問題
-
-### 🎛️ 配置文件格式規範
-
-- **標準化配置格式：** 創建統一的元件配置文件格式規範
-- **類型安全：** 完善的 TypeScript 類型定義，確保配置的類型安全
-- **可擴展性：** 支援自定義元件類型和配置選項
-
-### 🧹 程式碼優化
-
-- **測試文件清理：** 移除未使用的測試配置和依賴，減少專案體積
-- **程式碼結構優化：** 改進元件架構，提升程式碼可維護性
-- **效能提升：** 優化元件載入邏輯，提升頁面渲染效能
-
----
-
 ## ✨ 功能特性
 
 ### 🎨 設計與界面
@@ -78,36 +41,43 @@
 - [x] 基於 [Astro](https://astro.build) 和 [Tailwind CSS](https://tailwindcss.com) 構建
 - [x] 使用 [Swup](https://swup.js.org/) 實現流暢的動畫和頁面過渡
 - [x] 明暗主題切換，支援系統偏好檢測
-- [x] 可自定義主題色彩和動態橫幅輪播
-- [x] 全屏背景圖片，支援輪播、透明度和模糊效果
+- [x] 可自定義主題色彩、橫幅輪播和全屏桌布
+- [x] 可切換桌布模式，並調整透明度和模糊效果
+- [x] 可配置側邊欄元件、順序和響應式佈局
+- [x] 可選的寬螢幕自動頁面縮放
 - [x] 全裝置響應式設計
-- [x] 使用 JetBrains Mono 字體的優美排版
+- [x] 支援自訂或系統字體模式，包括 JetBrains Mono 和中日韓字體
 
 ### 🔍 內容與搜尋
 
 - [x] 基於 [Pagefind](https://pagefind.app/) 的高級搜尋功能
-- [x] [增強的 Markdown 功能](#-markdown-擴展語法)，支援語法高亮
+- [x] [Markdown 和 MDX 擴展](#-markdown-擴展語法)，支援語法高亮
 - [x] 互動式目錄，支援自動滾動
-- [x] RSS 訂閱生成
+- [x] RSS 和 Atom 全文訂閱，複用文章頁面的 Markdown/MDX 管線
 - [x] 閱讀時間估算
-- [x] 文章分類和標籤系統
+- [x] 文章分類、標籤、置頂、別名和自訂固定連結
+- [x] 可選的密碼保護文章，並明確說明靜態網站加密的安全邊界
 
 ### 📱 特色頁面
 
-- [x] **追番頁面** - 追蹤動畫觀看進度和評分
-- [x] **友鏈頁面** - 精美卡片展示朋友網站
-- [x] **日記頁面** - 分享生活瞬間，類似社交媒體
-- [x] **歸檔頁面** - 有序的文章時間線視圖
-- [x] **關於頁面** - 可自定義的個人介紹
+- [x] **追番頁面** - 使用本地資料、Bangumi 或 Bilibili 追蹤動畫
+- [x] **友鏈頁面** - 使用卡片和標籤展示友鏈
+- [x] **日記頁面** - 分享帶有文字、圖片、位置、心情和標籤的動態
+- [x] **相簿頁面** - 管理本地或外部相簿，並支援可選加密
+- [x] **專案、技能、裝置和時間線頁面** - 展示結構化個人資料
+- [x] **AI 工具頁面** - 維護可搜尋的工具目錄
+- [x] **歸檔和關於頁面** - 瀏覽文章或發布自訂介紹
 
 ### 🛠 技術特性
 
 - [x] **增強程式碼區塊**，基於 [Expressive Code](https://expressive-code.com/)
-- [x] **數學公式支援**，KaTeX 渲染
-- [x] **圖片優化**，PhotoSwipe 畫廊整合
-- [x] **SEO 優化**，包含網站地圖和元標籤
+- [x] **數學公式**，使用 KaTeX，並支援 Mermaid 和 PlantUML 圖表
+- [x] **圖片增強**，包括響應式尺寸、自動網格和 Fancybox 燈箱
+- [x] **SEO 優化**，包括網站地圖、robots.txt、RSS、Atom 和可選 Open Graph 圖片
 - [x] **效能優化**，懶加載和快取機制
-- [x] **評論系統**，支援 Twikoo 整合
+- [x] **評論系統**，支援 Twikoo 或 Giscus
+- [x] **音樂播放器**，支援本地和 Meting 模式
+- [x] **Live2D 看板娘**，透過 Pio 實現
 
 ## 🚀 快速開始
 
@@ -123,30 +93,34 @@
 2. **安裝依賴：**
 
    ```bash
-   # 如果沒有安裝 pnpm，先安裝
-   npm install -g pnpm
+   # 啟用專案宣告的套件管理器版本
+   corepack enable
 
    # 安裝專案依賴
    pnpm install
    ```
 
-3. **配置部落格：**
-   - 編輯 `src/config.ts` 自定義部落格設置
-   - 更新網站資訊、主題色彩、橫幅圖片和社交連結
-   - 配置翻譯設置和特色頁面功能
+3. **配置部落格（可選）：**
+   - 如果只使用本地內容，請在專案根目錄 `.env` 中設定 `ENABLE_CONTENT_SYNC=false`。
+   - 編輯 `src/config/siteConfig.ts` 和 `src/config/` 下的其他模組自訂網站。
+   - 至少將 `siteURL` 替換為部署後的公開網址。
 
 4. **啟動開發伺服器：**
    ```bash
    pnpm dev
    ```
-   部落格將在 `http://localhost:4321` 可用
+   部落格將在 `http://localhost:3000` 可用
 
 ### 📝 內容管理
 
-- **創建新文章：** `pnpm new-post <檔案名>`
-- **編輯文章：** 修改 `src/content/posts/` 中的檔案
-- **自定義頁面：** 編輯 `src/content/spec/` 中的特殊頁面
-- **添加圖片：** 將圖片放在 `src/assets/` 或 `public/` 中
+- **建立文章：** `pnpm new-post -- <檔案名>`，支援 `.md` 和 `.mdx`。
+- **編輯文章：** 修改 `src/content/posts/` 中的檔案。
+- **編輯關於頁或友鏈頁內容：** 修改 `src/content/spec/` 中對應的檔案。
+- **編輯結構化頁面資料：** 修改 `src/data/` 中對應的檔案。
+- **添加文章本地圖片：** 將圖片放在文章旁邊，並使用 `./cover.webp` 這樣的相對路徑。
+- **添加公共圖片：** 放在 `public/` 下，並使用 `/images/example.webp` 這樣的根路徑。
+
+> **發布前注意：** 儲存庫中包含示例文章、頁面資料、相簿和圖片。部署個人網站前請刪除或替換這些示例內容。
 
 ### 🚀 部署
 
@@ -157,183 +131,160 @@
 - **GitHub Pages：** 使用包含的 GitHub Actions 工作流
 - **Cloudflare Pages：** 連接您的儲存庫
 
-部署前，請在 `src/config.ts` 中更新 `siteURL`。
+部署前，請在 `src/config/siteConfig.ts` 中更新 `siteURL`。
+不要將 `.env` 或憑據提交到 Git；託管構建請在平台的環境變數設定中配置。
 
-- **環境變數配置（可選）：** 可參照 `.env.example` 來配置
-  **不建議**將 `.env` 檔案提交到 Git，`.env` 應該僅在本地調試或構建使用。若要將項目在雲平台部署，建議通過平台上的 `環境變數` 配置傳入。
+`.env.example` 中還包含 Bilibili 會話資料和 IndexNow 憑據等可選設定。只在需要時設定，並放在本地環境或託管平台 Secret 中，切勿提交真實值。
 
-## 📝 文章前言格式
+## 📝 內容編寫
 
-```yaml
----
-title: 我的第一篇部落格文章
-published: 2023-09-09
-description: 這是我新部落格的第一篇文章。
-image: ./cover.jpg
-tags: [標籤1, 標籤2]
-category: 前端
-draft: false
-pinned: false
-comment: true
-lang: zh-TW # 僅當文章語言與 config.ts 中的網站語言不同時設置
----
-```
+文章使用 `src/content/posts/` 下的 `.md` 或 `.mdx` 檔案，`title` 和 `published` 是必填的 frontmatter 欄位。可選欄位支援摘要、圖片、標籤、分類、草稿、置頂、評論、別名、固定連結、署名和瀏覽器端加密。
 
-### Frontmatter 欄位說明
+Markdown 和 MDX 支援提示框、KaTeX 數學公式、Expressive Code、Mermaid、PlantUML、GitHub 卡片、Wiki Link、劇透、響應式圖片、圖片網格、Fancybox 燈箱和 HTML 嵌入。加密文章不會進入 RSS 和 Atom，但瀏覽器端加密不是伺服器端存取控制。
 
-- **title**: 文章標題（必要）
-- **published**: 發布日期（必要）
-- **description**: 文章描述，用於 SEO 和預覽
-- **image**: 封面圖片路徑（相對於文章檔案）
-- **tags**: 標籤陣列，用於分類
-- **category**: 文章分類
-- **draft**: 設置為 `true` 在生產環境中隱藏文章
-- **pinned**: 設置為 `true` 將文章置頂
-- **comment**: 設置為 `true` 啟用文章評論區（需全域啟用評論功能）
-- **lang**: 文章語言（僅當與網站預設語言不同時設置）
+PlantUML 預設使用 `src/config/markdownConfig.ts` 中配置的公共伺服器，請勿在圖表中寫入密碼、Token 或隱私資料。
 
-### 置頂文章功能
-
-`pinned` 欄位允許您將重要文章置頂到部落格列表的頂部。置頂文章將始終顯示在普通文章之前，無論其發布日期如何。
-
-**使用方法：**
-
-```yaml
-pinned: true  # 將此文章置頂
-pinned: false # 普通文章（預設）
-```
-
-**排序規則：**
-
-1. 置頂文章優先顯示，按發布日期排序（最新在前）
-2. 普通文章隨後顯示，按發布日期排序（最新在前）
-
-### 文章級評論控制
-
-`comment` 欄位允許您單獨控制每篇文章評論區的開啟與關閉。
-
-**使用方法：**
-
-```yaml
-comment: true  # 啟用評論（預設）
-comment: false # 禁用評論
-```
-
-**注意：**
-此功能需要先在 `src/config.ts` 中啟用評論系統。
-
-## 🧩 Markdown 擴展語法
-
-Mizuki 支援超越標準 GitHub Flavored Markdown 的增強功能：
-
-### 📝 增強寫作
-
-- **提示框：** 使用 `> [!NOTE]`、`> [!TIP]`、`> [!WARNING]` 等創建精美的標註框
-- **數學公式：** 使用 `$行內$` 和 `$$塊級$$` 語法編寫 LaTeX 數學公式
-- **程式碼高亮：** 高級語法高亮，支援行號和複製按鈕
-- **GitHub 卡片：** 使用 `::github{repo="使用者/儲存庫"}` 嵌入儲存庫卡片
-
-### 🎨 視覺元素
-
-- **圖片畫廊：** 自動 PhotoSwipe 整合，支援圖片查看
-- **可折疊部分：** 創建可展開的內容區塊
-- **自定義元件：** 使用特殊指令增強內容
-
-### 📊 內容組織
-
-- **目錄：** 從標題自動生成，支援平滑滾動
-- **閱讀時間：** 自動計算和顯示
-- **文章元數據：** 豐富的前言支援，包含分類和標籤
+完整欄位表、寫作語法、圖片規則、圖表、影片嵌入、加密限制和發布清單請參閱[內容編寫指南](docs/CONTENT_AUTHORING.tw.md)。
 
 ## ⚡ 命令
 
 所有命令都在專案根目錄運行：
 
-| 命令                     | 操作                                   |
-| :----------------------- | :------------------------------------- |
-| `pnpm install`           | 安裝依賴                               |
-| `pnpm dev`               | 在 `localhost:4321` 啟動本地開發伺服器 |
-| `pnpm build`             | 構建生產網站到 `./dist/`               |
-| `pnpm preview`           | 在部署前本地預覽構建                   |
-| `pnpm check`             | 運行 Astro 錯誤檢查                    |
-| `pnpm format`            | 使用 Prettier 格式化程式碼             |
-| `pnpm lint`              | 檢查並修復程式碼問題                   |
-| `pnpm new-post <檔案名>` | 創建新部落格文章                       |
-| `pnpm astro ...`         | 運行 Astro CLI 命令                    |
+| 命令 | 操作 |
+| :--- | :--- |
+| `pnpm install` | 安裝依賴。 |
+| `pnpm dev` | 在 `http://localhost:3000` 啟動開發伺服器。 |
+| `pnpm build` | 構建 `./dist/`、生成搜尋資料並執行構建檢查。 |
+| `pnpm preview` | 在部署前預覽生產構建。 |
+| `pnpm run check` | 執行 Astro 診斷。 |
+| `pnpm run type-check` | 執行 TypeScript 類型檢查。 |
+| `pnpm test` | 執行 Markdown、佈局、圖片、音樂和加密測試。 |
+| `pnpm run format` | 使用 Biome 格式化源檔案。 |
+| `pnpm run lint` | 使用 Biome 檢查並自動修復源檔案。 |
+| `pnpm new-post -- <檔案名>` | 建立 Markdown 或 MDX 文章。 |
+| `pnpm run sync-content` | 同步可選的外部內容儲存庫。 |
+| `pnpm run init-content` | 互動式初始化外部內容同步。 |
+| `pnpm astro ...` | 執行 Astro CLI 命令。 |
 
 ## 🎯 配置指南
 
 ### 🔧 基礎配置
 
-編輯 `src/config.ts` 自定義您的部落格：
+配置已拆分到 `src/config/` 下的多個模組，`src/config/index.ts` 是統一導出入口。主要網站設定位於 `src/config/siteConfig.ts`：
 
 ```typescript
 export const siteConfig: SiteConfig = {
   title: "您的部落格名稱",
   subtitle: "您的部落格描述",
-  lang: "zh-TW", // 或 "zh-CN"、"en"、"ja" 等
-  timeZone: "Asia/Shanghai", // IANA 時區，例如 Asia/Tokyo 或 Europe/Berlin
+  siteURL: "https://example.com/", // 保留結尾斜線
+  lang: "zh_TW", // 例如 "en"、"zh_CN" 或 "ja"
+  timeZone: "Asia/Taipei", // 任意有效的 IANA 時區
   themeColor: {
-    hue: 210, // 0-360，主題色調
-    fixed: false, // 隱藏主題色選擇器
+    hue: 210, // 0–360
+    fixed: false, // 為 true 時隱藏訪客的主題色選擇器
   },
-  banner: {
-    enable: true,
-    src: ["assets/banner/1.webp"], // 橫幅圖片
-    carousel: {
-      enable: true,
-      interval: 0.8, // 秒
-    },
+  featurePages: {
+    anime: true,
+    diary: true,
+    friends: true,
+    projects: true,
+    skills: true,
+    timeline: true,
+    albums: true,
+    devices: true,
+    aiTools: true,
   },
+  // 其餘欄位請保留模板預設值。
 };
 ```
 
-### 📱 特色頁面配置
+其他常用配置檔案：
 
-- **追番頁面：** 在 `src/pages/anime.astro` 中編輯動畫列表
-- **友鏈頁面：** 在 `src/content/spec/friends.md` 中編輯朋友數據
-- **日記頁面：** 在 `src/pages/diary.astro` 中編輯動態
-- **關於頁面：** 在 `src/content/spec/about.md` 中編輯內容
+- `src/config/navBarConfig.ts` — 導航連結和選單。
+- `src/config/profileConfig.ts` — 頭像、名稱、簡介和社交連結。
+- `src/config/sidebarConfig.ts` — 側邊欄元件、順序、位置和響應式行為。
+- `src/config/backgroundWallpaper.ts` 與 `src/config/effectsConfig.ts` — 桌布和視覺特效。
+- `src/config/commentConfig.ts` — Twikoo 或 Giscus 全域設定。評論預設關閉；使用前請設定 `enable: true` 並配置對應服務。
+- `src/config/musicConfig.ts` — 音樂播放器模式和歌單來源。
+- `src/config/markdownConfig.ts` — Wiki Link、自動圖片網格和 PlantUML。
+- `src/config/permalinkConfig.ts` — 可選的全域固定連結格式。
+- `src/config/expressiveCodeConfig.ts` — 程式碼區塊主題和行為。
+
+### 📱 特色頁面內容
+
+頁面開關由 `siteConfig.featurePages` 控制。頁面內容與頁面模板分離：
+
+| 頁面 | 內容或資料來源 |
+| :--- | :--- |
+| 關於 | `src/content/spec/about.md` |
+| 友鏈 | `src/content/spec/friends.md` 和 `src/data/friends.ts` |
+| 追番 | `src/config/siteConfig.ts` 設定資料來源模式；本地資料在 `src/data/anime.ts` |
+| 日記 | `src/data/diary.ts`，或在 `diaryApiUrl` 中配置 Memos 地址 |
+| 相簿 | `public/images/albums/`；每個本地相簿使用 `info.json` |
+| 專案 | `src/data/projects.ts` |
+| 技能 | `src/data/skills.ts` |
+| 裝置 | `src/data/devices.ts` |
+| 時間線 | `src/data/timeline.ts` |
+| AI 工具 | `src/data/ai-tools.ts` |
+
+不要為了修改頁面內容而直接編輯 `src/pages/*.astro`；這些檔案負責佈局和渲染邏輯。
 
 ### 📦 代碼內容分離 (可選)
 
-Mizuki 支援將代碼和內容分成兩個獨立的倉庫管理，適合團隊協作和大型專案。
+Mizuki 可以將主題程式碼和部落格內容分成兩個儲存庫，適用於私有內容、獨立版本管理或團隊協作，但這是可選功能。
 
 **快速選擇**:
 
-| 使用場景               | 配置方式                        | 適合人群           |
-| ---------------------- | ------------------------------- | ------------------ |
-| 🆕 **本地模式** (預設) | 不配置，直接使用                | 新手、個人部落格   |
-| 🔧 **分離模式**        | 設置 `ENABLE_CONTENT_SYNC=true` | 團隊協作、私有內容 |
+| 使用場景 | 配置方式 | 內容位置 |
+| :--- | :--- | :--- |
+| **本地內容** | `ENABLE_CONTENT_SYNC=false` | `src/content/`、`src/data/` 和 `public/images/` |
+| **外部內容儲存庫** | `ENABLE_CONTENT_SYNC=true` 且設定 `CONTENT_REPO_URL=...` | 同步到上述路徑的獨立儲存庫 |
 
 **一鍵啟用/禁用**:
 
 ```bash
-# 方式 1: 本地模式 (推薦新手)
-# 不創建 .env 文件，直接運行
+# 本地內容模式（推薦入門使用）
+# 在 .env 中明確關閉同步
+ENABLE_CONTENT_SYNC=false
 pnpm dev
 
-# 方式 2: 內容分離模式
-# 1. 複製配置文件
+# 外部內容儲存庫模式
+# 1. 複製配置範例
 cp .env.example .env
 
-# 2. 編輯 .env，啟用內容分離
+# 2. 編輯 .env
 ENABLE_CONTENT_SYNC=true
 CONTENT_REPO_URL=https://github.com/your-username/Mizuki-Content.git
+# CONTENT_DIR=./content  # 可選，預設值即為此路徑
 
-# 3. 同步內容
+# 3. 同步內容並啟動網站
 pnpm run sync-content
+pnpm dev
 ```
 
-**功能特性**:
+外部內容儲存庫可以使用以下結構：
 
-- ✅ 支援公開和私有倉庫 🔐
-- ✅ 一鍵啟用/禁用，無需修改代碼
-- ✅ 自動同步，開發前自動拉取最新內容
+```text
+Mizuki-Content/
+├── posts/       # .md 和 .mdx 文章
+├── spec/        # 關於頁、友鏈頁等 Markdown 內容
+├── data/        # 專案、技能等結構化頁面資料
+└── images/      # 公共圖片，包括相簿和文章資源
+```
 
-📖 **詳細配置**: [內容分離完整指南](docs/CONTENT_SEPARATION.md)
-🔄 **遷移教程**: [從單倉庫遷移到分離模式](docs/MIGRATION_GUIDE.md)
-📚 **更多文檔**: [文檔索引](docs/README.md)
+同步腳本會將這些目錄映射到 `src/content/posts/`、`src/content/spec/`、`src/data/` 和 `public/images/`。`src/data/ai-tools.ts` 屬於程式碼儲存庫，會在同步時受到保護。
+
+> **同步警告：** 啟用 `ENABLE_CONTENT_SYNC` 後，`pnpm dev` 和 `pnpm build` 會自動執行同步鉤子。如果 `CONTENT_DIR` 已經是 Git 儲存庫，同步腳本會 fetch 並重置到遠端 `main` 或 `master` 分支；它還可能將現有執行時目錄備份為 `.backup`、建立目錄聯接或複製檔案，並在程式碼儲存庫中提交同步結果。執行前請提交或備份本地內容修改，不要直接編輯同步目標檔案。
+
+私有儲存庫可以使用 SSH URL，或透過部署平台配置憑據。不要將 Token 寫入 `.env` 並提交，也不要將 Token 放進公開儲存庫 URL。
+
+📖 **詳細配置：** [內容分離完整指南](docs/CONTENT_SEPARATION.md)
+
+🔄 **遷移教程：** [從單倉庫遷移到分離模式](docs/MIGRATION_GUIDE.md)
+
+🚀 **部署指南：** [部署指南](docs/DEPLOYMENT.md)
+
+📚 **更多文檔：** [文檔索引](docs/README.md)
 
 ## ✏️ 貢獻
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -4,9 +4,9 @@
 
 一个现代化、功能丰富的静态博客模板，基于 [Astro](https://astro.build) 构建，具有先进的功能和精美的设计。
 
-[![Node.js >= 22](https://img.shields.io/badge/node.js-%3E%3D22-brightgreen)](https://nodejs.org/)
-[![pnpm >= 9](https://img.shields.io/badge/pnpm-%3E%3D9-blue)](https://pnpm.io/)
-[![Astro](https://img.shields.io/badge/Astro-7.0.4-orange)](https://astro.build/)
+[![Node.js >= 20](https://img.shields.io/badge/node.js-%3E%3D20-brightgreen)](https://nodejs.org/)
+[![pnpm >= 11](https://img.shields.io/badge/pnpm-%3E%3D11-blue)](https://pnpm.io/)
+[![Astro](https://img.shields.io/badge/Astro-7.1.3-orange)](https://astro.build/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0.3-blue)](https://www.typescriptlang.org/)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg?logo=apache)](https://opensource.org/licenses/Apache-2.0)
 
@@ -34,43 +34,6 @@
   <tr>
 </table>
 
-## 🚀 NEW: 自动分辨率适配
-
-> **🎯 自动分辨率算法** - 智能适配内容布局基于设备屏幕分辨率，为所有设备提供最佳观看体验
-
-🌏 README 语言
-[**English**](./README.md) /
-[**中文**](./README.zh.md) /
-[**日本語**](./README.ja.md) /
-[**繁體中文**](./README.tw.md) /
-
-### 🔧 组件配置系统重构
-
-- **统一配置架构：** 全新的模块化组件配置体系，支持动态组件管理和顺序配置
-- **配置驱动的组件加载：** 重构 SideBar 组件，实现完全基于配置的组件加载机制
-- **统一控制开关：** 移除音乐播放器和公告组件的独立 enable 开关，统一由 sidebarLayoutConfig 控制
-- **响应式布局适配：** 组件支持响应式布局，可根据设备类型自动调整显示
-
-### 📐 布局系统优化
-
-- **侧边栏位置动态调整：** 支持左右侧边栏切换，布局自动适配
-- **文章目录智能定位：** 当侧边栏在右侧时，文章导航自动移至左侧，提供更好的阅读体验
-- **网格布局改进：** 优化 CSS Grid 布局，解决容器宽度异常问题
-
-### 🎛️ 配置文件格式标准化
-
-- **标准化配置格式：** 创建统一的组件配置文件格式规范
-- **类型安全：** 完善的 TypeScript 类型定义，确保配置的类型安全
-- **可扩展性：** 支持自定义组件类型和配置选项
-
-### 🧹 代码优化
-
-- **测试文件清理：** 移除未使用的测试配置和依赖，减少项目体积
-- **代码结构优化：** 改进组件架构，提升代码可维护性
-- **性能提升：** 优化组件加载逻辑，提升页面渲染性能
-
----
-
 ## ✨ 功能特性
 
 ### 🎨 设计与界面
@@ -78,36 +41,43 @@
 - [x] 基于 [Astro](https://astro.build) 和 [Tailwind CSS](https://tailwindcss.com) 构建
 - [x] 使用 [Swup](https://swup.js.org/) 实现流畅的动画和页面过渡
 - [x] 明暗主题切换，支持系统偏好检测
-- [x] 可自定义主题色彩和动态横幅轮播
-- [x] 全屏背景图片，支持轮播、透明度和模糊效果
+- [x] 可自定义主题色彩、横幅轮播和全屏壁纸
+- [x] 可切换壁纸模式，并调整透明度和模糊效果
+- [x] 可配置侧边栏组件、顺序和响应式布局
+- [x] 可选的宽屏自动页面缩放
 - [x] 全设备响应式设计
-- [x] 使用 JetBrains Mono 字体的优美排版
+- [x] 支持自定义或系统字体模式，包括 JetBrains Mono 和中日韩字体
 
 ### 🔍 内容与搜索
 
 - [x] 基于 [Pagefind](https://pagefind.app/) 的高级搜索功能
-- [x] [增强的 Markdown 功能](#-markdown-扩展语法)，支持语法高亮
+- [x] [Markdown 和 MDX 扩展](#-markdown-扩展语法)，支持语法高亮
 - [x] 交互式目录，支持自动滚动
-- [x] RSS 订阅生成
+- [x] RSS 和 Atom 全文订阅，复用文章页面的 Markdown/MDX 管线
 - [x] 阅读时间估算
-- [x] 文章分类和标签系统
+- [x] 文章分类、标签、置顶、别名和自定义固定链接
+- [x] 可选的密码保护文章，并明确静态站点加密的安全边界
 
 ### 📱 特色页面
 
-- [x] **追番页面** - 追踪动画观看进度和评分
-- [x] **友链页面** - 精美卡片展示朋友网站
-- [x] **日记页面** - 分享生活瞬间，类似社交媒体
-- [x] **归档页面** - 有序的文章时间线视图
-- [x] **关于页面** - 可自定义的个人介绍
+- [x] **追番页面** - 使用本地数据、Bangumi 或 Bilibili 追踪动画
+- [x] **友链页面** - 使用卡片和标签展示友链
+- [x] **日记页面** - 分享带有文字、图片、位置、心情和标签的动态
+- [x] **相册页面** - 管理本地或外部相册，并支持可选加密
+- [x] **项目、技能、设备和时间线页面** - 展示结构化个人数据
+- [x] **AI 工具页面** - 维护可筛选的工具目录
+- [x] **归档和关于页面** - 浏览文章或发布自定义介绍
 
 ### 🛠 技术特性
 
 - [x] **增强代码块**，基于 [Expressive Code](https://expressive-code.com/)
-- [x] **数学公式支持**，KaTeX 渲染
-- [x] **图片优化**，PhotoSwipe 画廊集成
-- [x] **SEO 优化**，包含站点地图和元标签
+- [x] **数学公式**，使用 KaTeX，并支持 Mermaid 和 PlantUML 图表
+- [x] **图片增强**，包括响应式尺寸、自动网格和 Fancybox 灯箱
+- [x] **SEO 优化**，包括站点地图、robots.txt、RSS、Atom 和可选 Open Graph 图片
 - [x] **性能优化**，懒加载和缓存机制
-- [x] **评论系统**，支持 Twikoo 集成
+- [x] **评论系统**，支持 Twikoo 或 Giscus
+- [x] **音乐播放器**，支持本地和 Meting 模式
+- [x] **Live2D 看板娘**，通过 Pio 实现
 
 ## 🚀 快速开始
 
@@ -123,31 +93,34 @@
 2. **安装依赖：**
 
    ```bash
-   # 如果没有安装 pnpm，先安装
-   npm install -g pnpm
+   # 启用项目声明的包管理器版本
+   corepack enable
 
    # 安装项目依赖
    pnpm install
    ```
 
-3. **配置博客：**
-   - 编辑 `src/config.ts` 自定义博客设置
-   - 更新站点信息、主题色彩、横幅图片和社交链接
-   - 配置特色页面功能
-   - (可选) 配置内容仓库分离 - 见 [内容仓库配置](#-代码内容分离可选)
+3. **配置博客（可选）：**
+   - 如果只使用本地内容，请在项目根目录 `.env` 中设置 `ENABLE_CONTENT_SYNC=false`。
+   - 编辑 `src/config/siteConfig.ts` 和 `src/config/` 下的其他模块自定义站点。
+   - 至少将 `siteURL` 替换为部署后的公开网址。
 
 4. **启动开发服务器：**
    ```bash
    pnpm dev
    ```
-   博客将在 `http://localhost:4321` 可用
+   博客将在 `http://localhost:3000` 可用
 
 ### 📝 内容管理
 
-- **创建新文章：** `pnpm new-post <文件名>`
-- **编辑文章：** 修改 `src/content/posts/` 中的文件
-- **自定义页面：** 编辑 `src/content/spec/` 中的特殊页面
-- **添加图片：** 将图片放在 `src/assets/` 或 `public/` 中
+- **创建文章：** `pnpm new-post -- <文件名>`，支持 `.md` 和 `.mdx`。
+- **编辑文章：** 修改 `src/content/posts/` 中的文件。
+- **编辑关于页或友链页内容：** 修改 `src/content/spec/` 中对应的文件。
+- **编辑结构化页面数据：** 修改 `src/data/` 中对应的文件。
+- **添加文章本地图片：** 将图片放在文章旁边，并使用 `./cover.webp` 这样的相对路径。
+- **添加公共图片：** 放在 `public/` 下，并使用 `/images/example.webp` 这样的根路径。
+
+> **发布前注意：** 仓库中包含示例文章、页面数据、相册和图片。部署个人站点前请删除或替换这些示例内容。
 
 ### 🚀 部署
 
@@ -160,181 +133,159 @@
 
 - **环境变量配置（可选）：** 可参照 `.env.example` 来配置
 
-部署前，请在 `src/config.ts` 中更新 `siteURL`。
-**不建议**将 `.env` 文件提交到 Git，`.env` 应该仅在本地调试或构建使用。若要将项目在云平台部署，建议通过平台上的 `环境变量` 配置传入。
+部署前，请在 `src/config/siteConfig.ts` 中更新 `siteURL`。不要将 `.env` 或凭据提交到 Git；托管构建请在平台的环境变量设置中配置。
 
-## 📝 文章前言格式
+`.env.example` 中还包含 Bilibili 会话数据和 IndexNow 凭据等可选配置。只在需要时设置，并放在本地环境或托管平台 Secret 中，切勿提交真实值。
 
-```yaml
----
-title: 我的第一篇博客文章
-published: 2023-09-09
-description: 这是我新博客的第一篇文章。
-image: ./cover.jpg
-tags: [标签1, 标签2]
-category: 前端
-draft: false
-pinned: false
-comment: true
-lang: zh-CN # 仅当文章语言与 config.ts 中的站点语言不同时设置
----
-```
+## 📝 内容编写
 
-### Frontmatter 字段说明
+文章使用 `src/content/posts/` 下的 `.md` 或 `.mdx` 文件，`title` 和 `published` 是必填的 frontmatter 字段。可选字段支持摘要、图片、标签、分类、草稿、置顶、评论、别名、固定链接、署名和浏览器端加密。
 
-- **title**: 文章标题（必需）
-- **published**: 发布日期（必需）
-- **description**: 文章描述，用于 SEO 和预览
-- **image**: 封面图片路径（相对于文章文件）
-- **tags**: 标签数组，用于分类
-- **category**: 文章分类
-- **draft**: 设置为 `true` 在生产环境中隐藏文章
-- **pinned**: 设置为 `true` 将文章置顶
-- **comment**: 设置为 `true` 启用文章评论区（需全局启用评论功能）
-- **lang**: 文章语言（仅当与站点默认语言不同时设置）
+Markdown 和 MDX 支持提示框、KaTeX 数学公式、Expressive Code、Mermaid、PlantUML、GitHub 卡片、Wiki Link、剧透、响应式图片、图片网格、Fancybox 灯箱和 HTML 嵌入。加密文章不会进入 RSS 和 Atom，但浏览器端加密不是服务端访问控制。
 
-### 置顶文章功能
+PlantUML 默认使用 `src/config/markdownConfig.ts` 中配置的公共服务器，请勿在图表中写入密码、Token 或隐私数据。
 
-`pinned` 字段允许您将重要文章置顶到博客列表的顶部。置顶文章将始终显示在普通文章之前，无论其发布日期如何。
-
-**使用方法：**
-
-```yaml
-pinned: true  # 将此文章置顶
-pinned: false # 普通文章（默认）
-```
-
-**排序规则：**
-
-1. 置顶文章优先显示，按发布日期排序（最新在前）
-2. 普通文章随后显示，按发布日期排序（最新在前）
-
-### 文章级评论控制
-
-`comment` 字段允许您单独控制每篇文章评论区的开启与关闭。
-
-**使用方法：**
-
-```yaml
-comment: true  # 启用评论（默认）
-comment: false # 禁用评论
-```
-
-**注意：**
-此功能需要先在 `src/config.ts` 中启用评论系统。
-
-## 🧩 Markdown 扩展语法
-
-Mizuki 支持超越标准 GitHub Flavored Markdown 的增强功能：
-
-### 📝 增强写作
-
-- **提示框：** 使用 `> [!NOTE]`、`> [!TIP]`、`> [!WARNING]` 等创建精美的标注框
-- **数学公式：** 使用 `$行内$` 和 `$$块级$$` 语法编写 LaTeX 数学公式
-- **代码高亮：** 高级语法高亮，支持行号和复制按钮
-- **GitHub 卡片：** 使用 `::github{repo="用户/仓库"}` 嵌入仓库卡片
-
-### 🎨 视觉元素
-
-- **图片画廊：** 自动 PhotoSwipe 集成，支持图片查看
-- **可折叠部分：** 创建可展开的内容块
-- **自定义组件：** 使用特殊指令增强内容
-
-### 📊 内容组织
-
-- **目录：** 从标题自动生成，支持平滑滚动
-- **阅读时间：** 自动计算和显示
-- **文章元数据：** 丰富的前言支持，包含分类和标签
+完整字段表、写作语法、图片规则、图表、视频嵌入、加密限制和发布清单请参阅[内容编写指南](docs/CONTENT_AUTHORING.zh.md)。
 
 ## ⚡ 命令
 
 所有命令都在项目根目录运行：
 
-| 命令                     | 操作                                   |
-| :----------------------- | :------------------------------------- |
-| `pnpm install`           | 安装依赖                               |
-| `pnpm dev`               | 在 `localhost:4321` 启动本地开发服务器 |
-| `pnpm build`             | 构建生产站点到 `./dist/`               |
-| `pnpm preview`           | 在部署前本地预览构建                   |
-| `pnpm check`             | 运行 Astro 错误检查                    |
-| `pnpm format`            | 使用 Prettier 格式化代码               |
-| `pnpm lint`              | 检查并修复代码问题                     |
-| `pnpm new-post <文件名>` | 创建新博客文章                         |
-| `pnpm astro ...`         | 运行 Astro CLI 命令                    |
+| 命令 | 操作 |
+| :--- | :--- |
+| `pnpm install` | 安装依赖。 |
+| `pnpm dev` | 在 `http://localhost:3000` 启动开发服务器。 |
+| `pnpm build` | 构建 `./dist/`、生成搜索数据并执行构建检查。 |
+| `pnpm preview` | 在部署前预览生产构建。 |
+| `pnpm run check` | 运行 Astro 诊断。 |
+| `pnpm run type-check` | 运行 TypeScript 类型检查。 |
+| `pnpm test` | 运行 Markdown、布局、图片、音乐和加密测试。 |
+| `pnpm run format` | 使用 Biome 格式化源文件。 |
+| `pnpm run lint` | 使用 Biome 检查并自动修复源文件。 |
+| `pnpm new-post -- <文件名>` | 创建 Markdown 或 MDX 文章。 |
+| `pnpm run sync-content` | 同步可选的外部内容仓库。 |
+| `pnpm run init-content` | 交互式初始化外部内容同步。 |
+| `pnpm astro ...` | 运行 Astro CLI 命令。 |
 
 ## 🎯 配置指南
 
 ### 🔧 基础配置
 
-编辑 `src/config.ts` 自定义您的博客：
+配置已拆分到 `src/config/` 下的多个模块，`src/config/index.ts` 是统一导出入口。主要站点设置位于 `src/config/siteConfig.ts`：
 
 ```typescript
 export const siteConfig: SiteConfig = {
   title: "您的博客名称",
   subtitle: "您的博客描述",
-  lang: "zh-CN", // 或 "en"、"ja" 等
-  timeZone: "Asia/Shanghai", // IANA 时区，例如 Asia/Tokyo 或 Europe/Berlin
+  siteURL: "https://example.com/", // 保留结尾斜杠
+  lang: "zh_CN", // 例如 "en"、"ja" 或 "zh_TW"
+  timeZone: "Asia/Shanghai", // 任意有效的 IANA 时区
   themeColor: {
-    hue: 210, // 0-360，主题色调
-    fixed: false, // 隐藏主题色选择器
+    hue: 210, // 0–360
+    fixed: false, // 为 true 时隐藏访客的主题色选择器
   },
-  banner: {
-    enable: true,
-    src: ["assets/banner/1.webp"], // 横幅图片
-    carousel: {
-      enable: true,
-      interval: 0.8, // 秒
-    },
+  featurePages: {
+    anime: true,
+    diary: true,
+    friends: true,
+    projects: true,
+    skills: true,
+    timeline: true,
+    albums: true,
+    devices: true,
+    aiTools: true,
   },
+  // 其余字段请保留模板默认值。
 };
 ```
 
-### 📱 特色页面配置
+其他常用配置文件：
 
-- **追番页面：** 在 `src/pages/anime.astro` 中编辑动画列表
-- **友链页面：** 在 `src/content/spec/friends.md` 中编辑朋友数据
-- **日记页面：** 在 `src/pages/diary.astro` 中编辑动态
-- **关于页面：** 在 `src/content/spec/about.md` 中编辑内容
+- `src/config/navBarConfig.ts` — 导航链接和菜单。
+- `src/config/profileConfig.ts` — 头像、名称、简介和社交链接。
+- `src/config/sidebarConfig.ts` — 侧边栏组件、顺序、位置和响应式行为。
+- `src/config/backgroundWallpaper.ts` 与 `src/config/effectsConfig.ts` — 壁纸和视觉特效。
+- `src/config/commentConfig.ts` — Twikoo 或 Giscus 全局设置。评论默认关闭；使用前请设置 `enable: true` 并配置对应服务。
+- `src/config/musicConfig.ts` — 音乐播放器模式和歌单来源。
+- `src/config/markdownConfig.ts` — Wiki Link、自动图片网格和 PlantUML。
+- `src/config/permalinkConfig.ts` — 可选的全局固定链接格式。
+- `src/config/expressiveCodeConfig.ts` — 代码块主题和行为。
+
+### 📱 特色页面内容
+
+页面开关由 `siteConfig.featurePages` 控制。页面内容与页面模板分离：
+
+| 页面 | 内容或数据来源 |
+| :--- | :--- |
+| 关于 | `src/content/spec/about.md` |
+| 友链 | `src/content/spec/friends.md` 和 `src/data/friends.ts` |
+| 追番 | `src/config/siteConfig.ts` 设置数据源模式；本地数据在 `src/data/anime.ts` |
+| 日记 | `src/data/diary.ts`，或在 `diaryApiUrl` 中配置 Memos 地址 |
+| 相册 | `public/images/albums/`；每个本地相册使用 `info.json` |
+| 项目 | `src/data/projects.ts` |
+| 技能 | `src/data/skills.ts` |
+| 设备 | `src/data/devices.ts` |
+| 时间线 | `src/data/timeline.ts` |
+| AI 工具 | `src/data/ai-tools.ts` |
+
+不要为了修改页面内容而直接编辑 `src/pages/*.astro`；这些文件负责布局和渲染逻辑。
 
 ### 📦 代码内容分离 (可选)
 
-Mizuki 支持将代码和内容分成两个独立的仓库管理,适合团队协作和大型项目。
+Mizuki 可以将主题代码和博客内容分成两个仓库，适用于私有内容、独立版本管理或团队协作，但这是可选功能。
 
 **快速选择**:
 
-| 使用场景               | 配置方式                        | 适合人群           |
-| ---------------------- | ------------------------------- | ------------------ |
-| 🆕 **本地模式** (默认) | 不配置,直接使用                 | 新手、个人博客     |
-| 🔧 **分离模式**        | 设置 `ENABLE_CONTENT_SYNC=true` | 团队协作、私有内容 |
+| 使用场景 | 配置方式 | 内容位置 |
+| :--- | :--- | :--- |
+| **本地内容** | `ENABLE_CONTENT_SYNC=false` | `src/content/`、`src/data/` 和 `public/images/` |
+| **外部内容仓库** | `ENABLE_CONTENT_SYNC=true` 且设置 `CONTENT_REPO_URL=...` | 同步到上述路径的独立仓库 |
 
 **一键启用/禁用**:
 
 ```bash
-# 方式 1: 本地模式 (推荐新手)
-# 不创建 .env 文件,直接运行
+# 本地内容模式（推荐入门使用）
+# 在 .env 中显式关闭同步
+ENABLE_CONTENT_SYNC=false
 pnpm dev
 
-# 方式 2: 内容分离模式
-# 1. 复制配置文件
+# 外部内容仓库模式
+# 1. 复制配置示例
 cp .env.example .env
 
-# 2. 编辑 .env,启用内容分离
+# 2. 编辑 .env
 ENABLE_CONTENT_SYNC=true
 CONTENT_REPO_URL=https://github.com/your-username/Mizuki-Content.git
+# CONTENT_DIR=./content  # 可选，默认值即为此路径
 
-# 3. 同步内容
+# 3. 同步内容并启动站点
 pnpm run sync-content
+pnpm dev
 ```
 
-**功能特性**:
+外部内容仓库可以使用以下结构：
 
-- ✅ 支持公开和私有仓库 🔐
-- ✅ 一键启用/禁用,无需修改代码
-- ✅ 自动同步,开发前自动拉取最新内容
+```text
+Mizuki-Content/
+├── posts/       # .md 和 .mdx 文章
+├── spec/        # 关于页、友链页等 Markdown 内容
+├── data/        # 项目、技能等结构化页面数据
+└── images/      # 公共图片，包括相册和文章资源
+```
 
-📖 **详细配置**: [内容分离完整指南](docs/CONTENT_SEPARATION.md)  
-🔄 **迁移教程**: [从单仓库迁移到分离模式](docs/MIGRATION_GUIDE.md)  
-📚 **更多文档**: [文档索引](docs/README.md)
+同步脚本会将这些目录映射到 `src/content/posts/`、`src/content/spec/`、`src/data/` 和 `public/images/`。`src/data/ai-tools.ts` 属于代码仓库，会在同步时受到保护。
+
+> **同步警告：** 启用 `ENABLE_CONTENT_SYNC` 后，`pnpm dev` 和 `pnpm build` 会自动执行同步钩子。如果 `CONTENT_DIR` 已经是 Git 仓库，同步脚本会 fetch 并重置到远程 `main` 或 `master` 分支；它还可能将现有运行时目录备份为 `.backup`、创建目录联接或复制文件，并在代码仓库中提交同步结果。执行前请提交或备份本地内容修改，不要直接编辑同步目标文件。
+
+私有仓库可以使用 SSH URL，或通过部署平台配置凭据。不要将 Token 写入 `.env` 并提交，也不要将 Token 放进公开仓库 URL。
+
+📖 **详细配置：** [内容分离完整指南](docs/CONTENT_SEPARATION.md)
+
+🔄 **迁移教程：** [从单仓库迁移到分离模式](docs/MIGRATION_GUIDE.md)
+
+🚀 **部署指南：** [部署指南](docs/DEPLOYMENT.md)
+
+📚 **更多文档：** [文档索引](docs/README.md)
 
 ## ✏️ 贡献
 

--- a/docs/CONTENT_AUTHORING.ja.md
+++ b/docs/CONTENT_AUTHORING.ja.md
@@ -1,0 +1,258 @@
+# コンテンツ執筆ガイド
+
+言語： [English](CONTENT_AUTHORING.md) · [简体中文](CONTENT_AUTHORING.zh.md) · [繁體中文](CONTENT_AUTHORING.tw.md)
+
+このガイドでは Mizuki が対応しているコンテンツ形式を説明します。テーマのリポジトリにコンテンツを置く場合と、コンテンツ分離機能で別リポジトリから同期する場合の両方に適用されます。
+
+## コンテンツの場所
+
+ローカルモードでは、次のディレクトリを直接編集します。
+
+| コンテンツ | 場所 |
+| :--- | :--- |
+| 記事 | `src/content/posts/` |
+| Markdown ページ | `src/content/spec/` |
+| 構造化されたページデータ | `src/data/` |
+| 公開画像 | `public/images/` |
+
+コンテンツ分離を有効にすると、外部コンテンツリポジトリの `posts/`、`spec/`、`data/`、`images/` が上記の実行時ディレクトリへ同期されます。同期モードでは実行時ディレクトリを直接編集せず、コンテンツリポジトリ側を変更してください。
+
+記事は `.md` と `.mdx` に対応しています。単一ファイルだけでなく、`index.md`/ `index.mdx` と画像などのローカル素材を含むフォルダも使えます。
+
+~~~text
+src/content/posts/
+└── guides/
+    └── getting-started/
+        ├── index.md
+        └── cover.webp
+~~~
+
+## Frontmatter
+
+必須フィールドは `title` と `published` だけです。現在の schema は次のフィールドに対応しています。
+
+| フィールド | 型 | デフォルト | 説明 |
+| :--- | :--- | :--- | :--- |
+| `title` | string | 必須 | 記事タイトル。 |
+| `published` | date | 必須 | 公開日時。 |
+| `updated` | date | — | 最終更新日時。 |
+| `draft` | boolean | `false` | `true` の場合、本番の一覧から除外。 |
+| `description` | string | `""` | SEO、カード、プレビューに使う概要。 |
+| `image` | string | `""` | カバー画像。相対パス、ルート相対パス、リモート URL に対応。 |
+| `tags` | string[] | `[]` | 整理とフィルタリングに使うタグ。 |
+| `category` | string または null | `""` | 記事カテゴリ。 |
+| `lang` | string | `""` | サイトの言語と異なる記事言語。 |
+| `pinned` | boolean | `false` | 通常の記事より前に表示。 |
+| `priority` | number | — | ピン留め記事の順序。両方が設定されている場合は小さい値が先。 |
+| `comment` | boolean | `true` | グローバルのコメント機能が有効な場合にコメント欄を表示するか。 |
+| `author` | string | `""` | 任意の著者表記。 |
+| `sourceLink` | string | `""` | 任意の出典・参考リンク。 |
+| `licenseName` | string | `""` | 任意の記事ライセンス名。 |
+| `licenseUrl` | string | `""` | 任意のライセンス URL。 |
+| `encrypted` | boolean | `false` | ブラウザー側のパスワード保護を有効化。 |
+| `password` | string | `""` | 暗号化記事のパスワード。 |
+| `passwordHint` | string | `""` | パスワード入力画面に表示する任意のヒント。 |
+| `hideHomeContent` | boolean | — | ホーム/一覧の公開概要を隠す。パスワード設定時はデフォルトで隠す。 |
+| `alias` | string | — | `/posts/` 配下の別 URL。 |
+| `permalink` | string | — | サイトルートのカスタム URL。 `alias` より優先。 |
+
+例：
+
+~~~yaml
+---
+title: "最初のブログ記事"
+published: 2026-08-09T13:00:00+08:00
+updated: 2026-08-10
+description: "プレビューと SEO 用の短い概要。"
+image: ./cover.webp
+tags: [Astro, Blogging]
+category: Guides
+draft: false
+pinned: false
+comment: true
+lang: ja
+author: "あなたの名前"
+---
+~~~
+
+`published: 2026-08-09` のような日付だけの値も使えます。正確な時刻が必要な場合は、タイムゾーン付き ISO タイムスタンプを使用してください。古い `date` や `pubDate` は追加せず、現在の schema の `published` を使います。
+
+### 下書きとピン留め
+
+執筆中は `draft: true` を設定できます。下書きは開発中に表示されますが、本番の一覧と Feed から除外されます。
+
+`pinned: true` を設定すると通常の記事より前に表示されます。 `priority` があればそれを使い、なければ公開日で並びます。
+
+### Alias と Permalink
+
+`alias` は `/posts/` 配下になります。
+
+~~~yaml
+alias: "my-special-article"
+~~~
+
+`permalink` はサイトルート配下になり、`alias` より優先されます。
+
+~~~yaml
+permalink: "notes/my-special-article"
+~~~
+
+どちらにも先頭・末尾のスラッシュを付けず、サイト全体で一意にしてください。
+
+### 記事の暗号化
+
+~~~yaml
+encrypted: true
+password: "use-a-strong-password"
+passwordHint: "読者向けの任意のヒント"
+hideHomeContent: true
+~~~
+
+Mizuki はレンダリング済みの記事をブラウザー側で復号します。これはサーバー側のアクセス制御ではありません。暗号化されたペイロードも静的サイトと一緒に配信されるため、閲覧者はダウンロードまたは解析できます。認証情報、秘密鍵、高度に機密性の高い情報には使わないでください。暗号化記事は RSS と Atom Feed から除外されます。
+
+## Markdown と MDX
+
+標準 Markdown、HTML、`.mdx` に対応しています。プロジェクト内のコンポーネントであれば、MDX から Astro/Svelte コンポーネントをインポートし、クライアントディレクティブも利用できます。
+
+### コールアウト
+
+ディレクティブ形式：
+
+~~~markdown
+:::note[任意のタイトル]
+これは情報を知らせるノートです。
+:::
+
+:::warning{title="注意してください"}
+これは警告です。
+:::
+~~~
+
+主な種類は `note`、`tip`、`important`、`warning`、`caution` です。`info`、`success`、`danger`、`example` などの一般的な別名も利用可能なスタイルにマッピングされます。
+
+GitHub 形式のコールアウトにも対応しています。
+
+~~~markdown
+> [!NOTE]
+> これは情報を知らせるノートです。
+
+> [!WARNING]
+> これは警告です。
+~~~
+
+### コードと数式
+
+フェンス付きコードブロックは Expressive Code が処理します。構文ハイライト、行番号、言語ラベル、コピー操作、コードグループ、長いブロックの自動折りたたみに対応しています。
+
+インライン数式は `$...$`、表示数式は `$$...$$` を使います。ビルド時に KaTeX でレンダリングされます。
+
+### Mermaid と PlantUML
+
+Mermaid は `mermaid` フェンスを使います。
+
+~~~~markdown
+~~~mermaid
+graph LR
+    A[執筆] --> B[ビルド]
+    B --> C[デプロイ]
+~~~
+~~~~
+
+PlantUML は `plantuml` フェンスを使います。
+
+~~~~markdown
+~~~plantuml
+@startuml
+Alice -> Bob: Hello
+@enduml
+~~~
+~~~~
+
+PlantUML のソースは画像 URL にエンコードされ、デフォルトでは `src/config/markdownConfig.ts` に設定された公開サーバーへ送信されます。図にパスワード、Token、個人情報、その他の秘密情報を含めないでください。公開レンダリングが適切でない場合は、自分で用意したサーバーを使うか、機能を無効にしてください。
+
+### GitHub カード、Wiki Link、Spoiler
+
+GitHub リポジトリカード：
+
+~~~markdown
+::github{repo="owner/repository"}
+~~~
+
+別の記事へのリンク：
+
+~~~markdown
+[[guides/getting-started]]
+[[guides/getting-started#installation|インストール節を読む]]
+~~~
+
+単独行の Wiki Link は記事カードになり、行内の Wiki Link は通常の内部リンクになります。
+
+Spoiler は見た目を隠すだけです。
+
+~~~markdown
+答えは :spoiler[隠されたテキスト] です。
+~~~
+
+Spoiler をセキュリティ機能として使わないでください。パスワード入力が必要な場合は記事の暗号化を使い、静的サイトとしての制限を理解してください。
+
+### 画像
+
+相対画像は現在の記事ディレクトリから解決されます。ルート相対パスは `public/` を指し、HTTP(S) URL はリモート画像を指します。
+
+~~~markdown
+![ローカル画像](./diagram.webp)
+![公開画像](/images/posts/diagram.webp)
+![リモート画像](https://example.com/image.webp)
+~~~
+
+タイトルを付けるとキャプションになります。alt テキストに `w-N%` を付けると、画像を 1% から 100% の幅で中央寄せできます。
+
+~~~markdown
+![アーキテクチャ w-75%](./architecture.webp "コンテンツパイプライン")
+~~~
+
+### 画像グリッド
+
+列数、アスペクト比、フィット方法を指定する場合は `:::grid` を使います。
+
+~~~markdown
+:::grid{columns="3" aspect="16/9" fit="cover"}
+![1 枚目](./one.webp)
+
+![2 枚目](./two.webp)
+:::
+~~~
+
+`columns` は 1–6、`aspect` は正の比率、`fit` は `cover` または `contain` です。デフォルトでは、連続する画像だけの段落も最大 4 列の自動グリッドになります。各グリッドは独立した Fancybox ライトボックスグループを持ちます。
+
+### 動画の埋め込み
+
+埋め込みが許可されているサービスの iframe を Markdown または MDX に貼り付けます。YouTube と Bilibili には Embed オプションがあります。サイトで明確な理由がない限り、自動再生は避けてください。
+
+## リポジトリ内の実例
+
+以下は `src/content/posts/` にある実際の記事です。機能ごとの具体的な使い方を確認できます。いずれもデモコンテンツなので、自分のサイトを公開する前に削除または置き換えてください。
+
+| テーマ | 例 |
+| :--- | :--- |
+| フォルダ形式の記事構成と基本記事 | [`guide/index.md`](../src/content/posts/guide/index.md) |
+| 標準 Markdown の基本 | [`markdown-tutorial.md`](../src/content/posts/markdown-tutorial.md) |
+| コールアウト、GitHub カード、Wiki Link など | [`markdown-extended.md`](../src/content/posts/markdown-extended.md) |
+| Mermaid のフローチャートなど | [`markdown-mermaid.md`](../src/content/posts/markdown-mermaid.md) |
+| 画像グリッド、キャプション、レスポンシブ表示、ライトボックス | [`image-grid-demo.md`](../src/content/posts/image-grid-demo.md) |
+| YouTube と Bilibili の iframe | [`video.md`](../src/content/posts/video.md) |
+| ブラウザー側で暗号化する記事 | [`encrypted-post.md`](../src/content/posts/encrypted-post.md) |
+| MDX の import、JavaScript export、Astro コンポーネント | [`content-pipeline-fixture.mdx`](../src/content/posts/content-pipeline-fixture.mdx) |
+
+古いデモ記事には、現在の schema に含まれないフィールドが残っている場合があります。新しい記事では、このガイドとソースコードを正としてください。
+
+## 公開前チェックリスト
+
+1. 必須の frontmatter と日付形式を確認する。
+2. 画像パス、ファイル名の大文字小文字、リモート URL を確認する。
+3. コールアウト、グリッド、コードフェンス、図表ブロックをすべて閉じる。
+4. alias と permalink がサイト内で一意であることを確認する。
+5. PlantUML、MDX、公開画像、記事本文に Secret を入れない。
+6. 個人サイトをデプロイする前に、リポジトリ付属のデモ記事、ページデータ、画像を削除または置き換える。
+
+詳細なレンダリング仕様は [Content Rendering](CONTENT_RENDERING.md) を参照してください。Markdown/MDX の実例は上記の記事からも確認できます。

--- a/docs/CONTENT_AUTHORING.md
+++ b/docs/CONTENT_AUTHORING.md
@@ -1,0 +1,262 @@
+# Content Authoring Guide
+
+This guide covers the content formats supported by Mizuki. It applies whether content is kept in the code repository or synchronized from a separate content repository.
+
+Language versions: [简体中文](CONTENT_AUTHORING.zh.md) · [日本語](CONTENT_AUTHORING.ja.md) · [繁體中文](CONTENT_AUTHORING.tw.md)
+
+## Content locations
+
+In local mode, edit these paths directly:
+
+| Content | Location |
+| :--- | :--- |
+| Posts | `src/content/posts/` |
+| Markdown page content | `src/content/spec/` |
+| Structured page data | `src/data/` |
+| Public images | `public/images/` |
+
+When content separation is enabled, the external repository maps `posts/`, `spec/`, `data/`, and `images/` to those four runtime locations. Do not edit synchronized runtime files directly.
+
+Posts may use either `.md` or `.mdx`. A post can be a single file or a folder containing `index.md`/`index.mdx` and local assets:
+
+```text
+src/content/posts/
+└── guides/
+    └── getting-started/
+        ├── index.md
+        └── cover.webp
+```
+
+## Frontmatter
+
+Only `title` and `published` are required. The schema supports the following fields:
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `title` | string | required | Article title. |
+| `published` | date | required | Publication date. |
+| `updated` | date | — | Last update date. |
+| `draft` | boolean | `false` | Hides the post from production listings when `true`. |
+| `description` | string | `""` | Summary for SEO, cards, and previews. |
+| `image` | string | `""` | Cover path; supports relative, root-relative, and remote URLs. |
+| `tags` | string[] | `[]` | Tags used for organization and filtering. |
+| `category` | string or null | `""` | Article category. |
+| `lang` | string | `""` | Article language when it differs from the site language. |
+| `pinned` | boolean | `false` | Places the post before regular posts. |
+| `priority` | number | — | Sorts pinned posts; lower values come first when both posts define it. |
+| `comment` | boolean | `true` | Enables the article comment area when the global comment system is enabled. |
+| `author` | string | `""` | Optional author attribution. |
+| `sourceLink` | string | `""` | Optional source or reference URL. |
+| `licenseName` | string | `""` | Optional license name for the article. |
+| `licenseUrl` | string | `""` | Optional license URL. |
+| `encrypted` | boolean | `false` | Enables browser-side password protection. |
+| `password` | string | `""` | Password used for the encrypted post. |
+| `passwordHint` | string | `""` | Optional hint shown in the password prompt. |
+| `hideHomeContent` | boolean | — | Hides the public home/list summary; posts with a password hide it by default. |
+| `alias` | string | — | Alternate URL under `/posts/`. |
+| `permalink` | string | — | Custom URL at the site root; takes precedence over `alias`. |
+
+Example:
+
+```yaml
+---
+title: "My First Blog Post"
+published: 2026-08-09T13:00:00+08:00
+updated: 2026-08-10
+description: "A short description for previews and SEO."
+image: ./cover.webp
+tags: [Astro, Blogging]
+category: Guides
+draft: false
+pinned: false
+comment: true
+lang: en
+author: "Your Name"
+---
+```
+
+Date-only values such as `published: 2026-08-09` are also valid. Use a timezone-qualified ISO timestamp when the exact instant matters. Do not add legacy `date` or `pubDate` fields; the current schema uses `published`.
+
+### Drafts and pinned posts
+
+Set `draft: true` while writing. Drafts are available during development but are excluded from production listings and feeds.
+
+Set `pinned: true` to place a post before regular posts. Pinned posts use `priority` when available, then fall back to publication date.
+
+### Aliases and permalinks
+
+An alias stays under `/posts/`:
+
+```yaml
+alias: "my-special-article"
+```
+
+A permalink is rooted at the site URL and has higher priority than an alias:
+
+```yaml
+permalink: "notes/my-special-article"
+```
+
+Do not include leading or trailing slashes. Keep aliases and permalinks unique across the site.
+
+### Post encryption
+
+```yaml
+encrypted: true
+password: "use-a-strong-password"
+passwordHint: "Optional hint for readers"
+hideHomeContent: true
+```
+
+Mizuki encrypts the rendered post for browser-side decryption. This is not server-side access control: the encrypted payload is still distributed with the static site, and a determined visitor can download or analyze it. Do not use this feature for credentials, private keys, or highly sensitive information. Encrypted posts are excluded from RSS and Atom feeds.
+
+## Markdown and MDX
+
+Standard Markdown, HTML, and `.mdx` files are supported. MDX can use imported Astro/Svelte components and client directives when those components are part of the project.
+
+### Callouts
+
+Directive callouts:
+
+```markdown
+:::note[Optional title]
+This is an informational note.
+:::
+
+:::warning{title="Be careful"}
+This is a warning.
+:::
+```
+
+The primary directive types are `note`, `tip`, `important`, `warning`, and `caution`. Common aliases such as `info`, `success`, `danger`, and `example` are also mapped to the available styles.
+
+GitHub-style callouts are supported as well:
+
+```markdown
+> [!NOTE]
+> This is an informational note.
+
+> [!WARNING]
+> This is a warning.
+```
+
+### Code blocks
+
+Fenced code blocks use Expressive Code. The theme provides syntax highlighting, line numbers, language labels, copy controls, code groups, and automatic collapsing for long blocks.
+
+### Math
+
+Use `$...$` for inline math and `$$...$$` for display math. KaTeX renders the result during the build.
+
+### Mermaid and PlantUML
+
+Mermaid diagrams use a `mermaid` fence:
+
+````markdown
+```mermaid
+graph LR
+    A[Write] --> B[Build]
+    B --> C[Deploy]
+```
+````
+
+PlantUML diagrams use a `plantuml` fence:
+
+````markdown
+```plantuml
+@startuml
+Alice -> Bob: Hello
+@enduml
+```
+````
+
+PlantUML source is encoded into an image URL and, by default, sent to the public server configured in `src/config/markdownConfig.ts`. Do not put passwords, tokens, personal data, or other confidential information in a diagram. Use a self-hosted server or disable the feature when public rendering is not appropriate.
+
+### GitHub cards, Wiki Links, and spoilers
+
+Embed a GitHub repository card with:
+
+```markdown
+::github{repo="owner/repository"}
+```
+
+Link to another post with a Wiki Link:
+
+```markdown
+[[guides/getting-started]]
+[[guides/getting-started#installation|Read the installation section]]
+```
+
+A Wiki Link on its own line becomes a post card. Inline Wiki Links become regular internal links.
+
+Spoilers are visual masking only:
+
+```markdown
+The answer is :spoiler[hidden text].
+```
+
+Do not use spoilers as a security feature. Use post encryption when a password prompt is appropriate, while keeping its static-site limitations in mind.
+
+### Images
+
+Relative images are resolved from the current post directory. Root-relative paths refer to `public/`, and HTTP(S) URLs refer to remote images:
+
+```markdown
+![Local image](./diagram.webp)
+![Public image](/images/posts/diagram.webp)
+![Remote image](https://example.com/image.webp)
+```
+
+Use a title for a caption and add `w-N%` to the alt text for a centered width from 1% to 100%:
+
+```markdown
+![Architecture w-75%](./architecture.webp "Content pipeline")
+```
+
+### Image grids
+
+Use an explicit grid when you need control over columns, aspect ratio, or fitting:
+
+```markdown
+:::grid{columns="3" aspect="16/9" fit="cover"}
+![First image](./one.webp)
+
+![Second image](./two.webp)
+:::
+```
+
+`columns` accepts 1–6, `aspect` must be a positive ratio, and `fit` is `cover` or `contain`. The default configuration also converts consecutive image-only paragraphs into an automatic grid of up to four columns. Each grid has its own Fancybox lightbox group.
+
+### Video embeds
+
+When a provider allows embedding, paste its iframe into the Markdown or MDX file. For example, YouTube and Bilibili both provide an Embed option. Avoid autoplay unless it is explicitly appropriate for the site.
+
+## Examples in this repository
+
+The following are real articles under [`src/content/posts/`](../src/content/posts/). They are useful as focused examples, but they are demo content; remove or replace them before deploying your own site.
+
+| Topic | Example |
+| :--- | :--- |
+| Folder-based post layout and a basic article | [`guide/index.md`](../src/content/posts/guide/index.md) |
+| Standard Markdown basics | [`markdown-tutorial.md`](../src/content/posts/markdown-tutorial.md) |
+| Callouts, GitHub cards, Wiki Links, and other extensions | [`markdown-extended.md`](../src/content/posts/markdown-extended.md) |
+| Mermaid flowcharts and other diagram types | [`markdown-mermaid.md`](../src/content/posts/markdown-mermaid.md) |
+| Image grids, captions, responsive behavior, and lightbox groups | [`image-grid-demo.md`](../src/content/posts/image-grid-demo.md) |
+| YouTube and Bilibili iframe embeds | [`video.md`](../src/content/posts/video.md) |
+| Browser-side encrypted posts | [`encrypted-post.md`](../src/content/posts/encrypted-post.md) |
+| MDX imports, JavaScript exports, and Astro components | [`content-pipeline-fixture.mdx`](../src/content/posts/content-pipeline-fixture.mdx) |
+
+The older demo articles may show fields that are no longer part of the current schema. For new posts, follow the schema in this guide and treat the source code as authoritative.
+
+## Content and feeds checklist
+
+Before publishing:
+
+1. Check required frontmatter and date formats.
+2. Verify image paths, filename casing, and remote URLs.
+3. Close every callout, grid, code fence, and diagram block.
+4. Confirm aliases and permalinks are unique.
+5. Keep secrets out of PlantUML, MDX, public images, and article content.
+6. Remove or replace the repository's demo posts, page data, and images before deploying a personal site.
+
+For a broader rendering overview, see [Content Rendering](CONTENT_RENDERING.md). The repository also includes working examples under `src/content/posts/`.

--- a/docs/CONTENT_AUTHORING.tw.md
+++ b/docs/CONTENT_AUTHORING.tw.md
@@ -1,0 +1,258 @@
+# 內容編寫指南
+
+語言版本：[English](CONTENT_AUTHORING.md) · [简体中文](CONTENT_AUTHORING.zh.md) · [日本語](CONTENT_AUTHORING.ja.md)
+
+本文介紹 Mizuki 支援的內容格式，適用於內容保存在主題倉庫，或透過內容分離功能從獨立倉庫同步的情況。
+
+## 內容位置
+
+本地模式下直接編輯以下目錄：
+
+| 內容 | 位置 |
+| :--- | :--- |
+| 文章 | `src/content/posts/` |
+| Markdown 頁面內容 | `src/content/spec/` |
+| 結構化頁面資料 | `src/data/` |
+| 公開圖片 | `public/images/` |
+
+啟用內容分離後，外部內容倉庫中的 `posts/`、`spec/`、`data/` 和 `images/` 會分別同步到上述執行時目錄。同步模式下不要直接編輯執行時目錄，請在內容倉庫中修改。
+
+文章支援 `.md` 和 `.mdx`，可以是單一檔案，也可以使用包含 `index.md`/ `index.mdx` 和本地素材的資料夾：
+
+~~~text
+src/content/posts/
+└── guides/
+    └── getting-started/
+        ├── index.md
+        └── cover.webp
+~~~
+
+## Frontmatter
+
+只有 `title` 和 `published` 是必填欄位。目前 schema 支援：
+
+| 欄位 | 型別 | 預設值 | 說明 |
+| :--- | :--- | :--- | :--- |
+| `title` | string | 必填 | 文章標題。 |
+| `published` | date | 必填 | 發布日期。 |
+| `updated` | date | — | 最後更新日期。 |
+| `draft` | boolean | `false` | 為 `true` 時，不會顯示在正式環境列表中。 |
+| `description` | string | `""` | 用於 SEO、卡片和預覽的摘要。 |
+| `image` | string | `""` | 封面路徑，支援相對路徑、根相對路徑和遠端 URL。 |
+| `tags` | string[] | `[]` | 用於組織和篩選的標籤。 |
+| `category` | string 或 null | `""` | 文章分類。 |
+| `lang` | string | `""` | 文章語言與網站語言不同時使用。 |
+| `pinned` | boolean | `false` | 將文章排在一般文章之前。 |
+| `priority` | number | — | 置頂文章排序，兩篇文章都設定時數值越小越靠前。 |
+| `comment` | boolean | `true` | 全域留言系統啟用時，控制本文是否顯示留言區。 |
+| `author` | string | `""` | 可選的作者署名。 |
+| `sourceLink` | string | `""` | 可選的來源或參考連結。 |
+| `licenseName` | string | `""` | 可選的文章授權名稱。 |
+| `licenseUrl` | string | `""` | 可選的授權連結。 |
+| `encrypted` | boolean | `false` | 啟用瀏覽器端密碼保護。 |
+| `password` | string | `""` | 加密文章使用的密碼。 |
+| `passwordHint` | string | `""` | 顯示在密碼輸入框附近的可選提示。 |
+| `hideHomeContent` | boolean | — | 隱藏公開首頁/列表摘要；設定密碼時預設隱藏。 |
+| `alias` | string | — | `/posts/` 下的替代 URL。 |
+| `permalink` | string | — | 網站根路徑下的自訂 URL，優先級高於 `alias`。 |
+
+範例：
+
+~~~yaml
+---
+title: "我的第一篇文章"
+published: 2026-08-09T13:00:00+08:00
+updated: 2026-08-10
+description: "用於預覽和 SEO 的簡短摘要。"
+image: ./cover.webp
+tags: [Astro, Blogging]
+category: Guides
+draft: false
+pinned: false
+comment: true
+lang: zh-TW
+author: "你的名字"
+---
+~~~
+
+僅日期格式（例如 `published: 2026-08-09`）也有效。如果需要表達確切時刻，請使用帶時區的 ISO 時間戳。不要新增舊版的 `date` 或 `pubDate` 欄位，目前 schema 使用 `published`。
+
+### 草稿與置頂
+
+寫作期間可以設定 `draft: true`。草稿在開發環境可見，但會從正式環境列表和 Feed 中排除。
+
+設定 `pinned: true` 可將文章排在一般文章之前；如果設定 `priority`，會優先按它排序，否則按發布日期排序。
+
+### 別名與固定連結
+
+`alias` 位於 `/posts/` 下：
+
+~~~yaml
+alias: "my-special-article"
+~~~
+
+`permalink` 位於網站根路徑下，且優先級高於 `alias`：
+
+~~~yaml
+permalink: "notes/my-special-article"
+~~~
+
+兩者都不要包含開頭或結尾的斜線，並確保在整個網站中唯一。
+
+### 文章加密
+
+~~~yaml
+encrypted: true
+password: "use-a-strong-password"
+passwordHint: "給讀者的可選提示"
+hideHomeContent: true
+~~~
+
+Mizuki 對渲染後的文章執行瀏覽器端解密。這不是伺服器端存取控制：加密內容仍會隨靜態網站分發，有能力的訪客可以下載或分析它。不要用來存放憑據、私鑰或高度敏感資訊。加密文章不會進入 RSS 和 Atom Feed。
+
+## Markdown 與 MDX
+
+支援標準 Markdown、HTML 和 `.mdx`。如果元件屬於目前專案，MDX 可以匯入 Astro/Svelte 元件並使用用戶端指令。
+
+### 提示區塊
+
+指令式提示區塊：
+
+~~~markdown
+:::note[可選標題]
+這是一個資訊提示。
+:::
+
+:::warning{title="請注意"}
+這是一個警告。
+:::
+~~~
+
+主要類型為 `note`、`tip`、`important`、`warning` 和 `caution`；`info`、`success`、`danger`、`example` 等常見別名也會映射到可用樣式。
+
+同時支援 GitHub 風格提示區塊：
+
+~~~markdown
+> [!NOTE]
+> 這是一個資訊提示。
+
+> [!WARNING]
+> 這是一個警告。
+~~~
+
+### 程式碼與數學公式
+
+圍欄程式碼區塊由 Expressive Code 渲染，提供語法高亮、行號、語言標籤、複製按鈕、程式碼群組，以及長區塊自動摺疊等功能。
+
+行內公式使用 `$...$`，獨立公式使用 `$$...$$`，建置時由 KaTeX 渲染。
+
+### Mermaid 與 PlantUML
+
+Mermaid 使用 `mermaid` 程式碼圍欄：
+
+~~~~markdown
+~~~mermaid
+graph LR
+    A[編寫] --> B[建置]
+    B --> C[部署]
+~~~
+~~~~
+
+PlantUML 使用 `plantuml` 程式碼圍欄：
+
+~~~~markdown
+~~~plantuml
+@startuml
+Alice -> Bob: Hello
+@enduml
+~~~
+~~~~
+
+PlantUML 原始碼會編碼到圖片 URL，預設傳送到 `src/config/markdownConfig.ts` 配置的公共伺服器。圖表中不要放入密碼、Token、個人資料或其他機密內容；不適合公開渲染時，請使用自建伺服器或停用此功能。
+
+### GitHub 卡片、Wiki Link 與 Spoiler
+
+GitHub 儲存庫卡片：
+
+~~~markdown
+::github{repo="owner/repository"}
+~~~
+
+連結到另一篇文章：
+
+~~~markdown
+[[guides/getting-started]]
+[[guides/getting-started#installation|閱讀安裝章節]]
+~~~
+
+單獨佔一行的 Wiki Link 會渲染為文章卡片，行內 Wiki Link 會渲染為一般站內連結。
+
+Spoiler 只是視覺遮罩：
+
+~~~markdown
+答案是 :spoiler[隱藏文字]。
+~~~
+
+不要把 Spoiler 當作安全功能；需要密碼提示時使用文章加密，並理解其靜態網站限制。
+
+### 圖片
+
+相對圖片從目前文章目錄解析，根相對路徑指向 `public/`，HTTP(S) URL 用於遠端圖片：
+
+~~~markdown
+![本地圖片](./diagram.webp)
+![公開圖片](/images/posts/diagram.webp)
+![遠端圖片](https://example.com/image.webp)
+~~~
+
+為圖片加入標題即可顯示說明文字；在 alt 文字中加入 `w-N%` 可將圖片寬度設定為 1% 到 100% 並置中：
+
+~~~markdown
+![架構圖 w-75%](./architecture.webp "內容管線")
+~~~
+
+### 圖片網格
+
+需要控制欄數、寬高比或填充方式時使用 `:::grid`：
+
+~~~markdown
+:::grid{columns="3" aspect="16/9" fit="cover"}
+![第一張圖片](./one.webp)
+
+![第二張圖片](./two.webp)
+:::
+~~~
+
+`columns` 支援 1–6，`aspect` 必須是正數比例，`fit` 為 `cover` 或 `contain`。預設配置也會把連續的純圖片段落轉換成最多四欄的自動網格。每個網格擁有獨立的 Fancybox 燈箱分組。
+
+### 影片嵌入
+
+在服務商允許嵌入的前提下，將其 Embed 選項提供的 iframe 貼到 Markdown 或 MDX 檔案中。YouTube 和 Bilibili 都提供嵌入程式碼；除非確有需要，否則不要啟用自動播放。
+
+## 倉庫中的真實範例
+
+以下是 `src/content/posts/` 下的真實文章，可按主題查看具體用法。它們屬於示範內容，部署個人網站前請刪除或替換：
+
+| 主題 | 範例 |
+| :--- | :--- |
+| 資料夾式文章結構和基礎文章 | [`guide/index.md`](../src/content/posts/guide/index.md) |
+| 標準 Markdown 基礎語法 | [`markdown-tutorial.md`](../src/content/posts/markdown-tutorial.md) |
+| 提示區塊、GitHub 卡片、Wiki Link 等擴充 | [`markdown-extended.md`](../src/content/posts/markdown-extended.md) |
+| Mermaid 流程圖及其他圖表 | [`markdown-mermaid.md`](../src/content/posts/markdown-mermaid.md) |
+| 圖片網格、標題、響應式行為和燈箱分組 | [`image-grid-demo.md`](../src/content/posts/image-grid-demo.md) |
+| YouTube 與 Bilibili iframe 嵌入 | [`video.md`](../src/content/posts/video.md) |
+| 瀏覽器端加密文章 | [`encrypted-post.md`](../src/content/posts/encrypted-post.md) |
+| MDX 匯入、JavaScript 匯出和 Astro 元件 | [`content-pipeline-fixture.mdx`](../src/content/posts/content-pipeline-fixture.mdx) |
+
+較早的示範文章可能仍展示已不屬於目前 schema 的欄位。新文章請以本文欄位表和原始碼為準。
+
+## 發布前清單
+
+1. 檢查必填 frontmatter 和日期格式。
+2. 檢查圖片路徑、檔名大小寫和遠端 URL。
+3. 確認每個提示區塊、網格、程式碼圍欄和圖表區塊都已閉合。
+4. 確認 alias 和 permalink 在網站中唯一。
+5. 不要把 Secret 放入 PlantUML、MDX、公開圖片或文章內容。
+6. 部署個人網站前，刪除或替換倉庫自帶的示範文章、頁面資料和圖片。
+
+更多渲染細節請參閱[內容渲染指南](CONTENT_RENDERING.md)；Markdown/MDX 擴充和實際文章用法也可以直接參考上述範例。

--- a/docs/CONTENT_AUTHORING.zh.md
+++ b/docs/CONTENT_AUTHORING.zh.md
@@ -1,0 +1,258 @@
+# 内容编写指南
+
+语言版本：[English](CONTENT_AUTHORING.md) · [日本語](CONTENT_AUTHORING.ja.md) · [繁體中文](CONTENT_AUTHORING.tw.md)
+
+本文介绍 Mizuki 支持的内容格式，适用于内容保存在主题仓库或通过内容分离功能从独立仓库同步的场景。
+
+## 内容位置
+
+本地模式下直接编辑以下目录：
+
+| 内容 | 位置 |
+| :--- | :--- |
+| 文章 | `src/content/posts/` |
+| Markdown 页面内容 | `src/content/spec/` |
+| 结构化页面数据 | `src/data/` |
+| 公共图片 | `public/images/` |
+
+启用内容分离后，外部内容仓库中的 `posts/`、`spec/`、`data/` 和 `images/` 会分别同步到上述运行时目录。同步模式下不要直接编辑运行时目录；请在内容仓库中修改。
+
+文章支持 `.md` 和 `.mdx`，既可以是单个文件，也可以使用包含 `index.md`/ `index.mdx` 和本地资源的目录：
+
+~~~text
+src/content/posts/
+└── guides/
+    └── getting-started/
+        ├── index.md
+        └── cover.webp
+~~~
+
+## Frontmatter
+
+只有 `title` 和 `published` 是必填字段。当前 schema 支持：
+
+| 字段 | 类型 | 默认值 | 说明 |
+| :--- | :--- | :--- | :--- |
+| `title` | string | 必填 | 文章标题。 |
+| `published` | date | 必填 | 发布日期。 |
+| `updated` | date | — | 最后更新时间。 |
+| `draft` | boolean | `false` | 为 `true` 时，生产环境列表中不显示。 |
+| `description` | string | `""` | 用于 SEO、卡片和预览的摘要。 |
+| `image` | string | `""` | 封面路径，支持相对路径、根相对路径和远程 URL。 |
+| `tags` | string[] | `[]` | 用于组织和筛选的标签。 |
+| `category` | string 或 null | `""` | 文章分类。 |
+| `lang` | string | `""` | 文章语言与站点语言不同时使用。 |
+| `pinned` | boolean | `false` | 将文章排在普通文章之前。 |
+| `priority` | number | — | 置顶文章排序，两个文章都设置时数值越小越靠前。 |
+| `comment` | boolean | `true` | 全局评论系统启用时，控制本文是否显示评论区。 |
+| `author` | string | `""` | 可选的作者署名。 |
+| `sourceLink` | string | `""` | 可选的来源或参考链接。 |
+| `licenseName` | string | `""` | 可选的文章许可证名称。 |
+| `licenseUrl` | string | `""` | 可选的许可证链接。 |
+| `encrypted` | boolean | `false` | 启用浏览器端密码保护。 |
+| `password` | string | `""` | 加密文章使用的密码。 |
+| `passwordHint` | string | `""` | 显示在密码输入框附近的可选提示。 |
+| `hideHomeContent` | boolean | — | 隐藏公开首页/列表摘要；设置密码时默认隐藏。 |
+| `alias` | string | — | `/posts/` 下的备用 URL。 |
+| `permalink` | string | — | 站点根路径下的自定义 URL，优先级高于 `alias`。 |
+
+示例：
+
+~~~yaml
+---
+title: "我的第一篇文章"
+published: 2026-08-09T13:00:00+08:00
+updated: 2026-08-10
+description: "用于预览和 SEO 的简短摘要。"
+image: ./cover.webp
+tags: [Astro, Blogging]
+category: Guides
+draft: false
+pinned: false
+comment: true
+lang: zh-CN
+author: "你的名字"
+---
+~~~
+
+仅日期格式（如 `published: 2026-08-09`）也有效。如果需要表达确切时刻，请使用带时区的 ISO 时间戳。不要新增旧版的 `date` 或 `pubDate` 字段；当前 schema 使用 `published`。
+
+### 草稿与置顶
+
+写作期间可设置 `draft: true`。草稿在开发环境可见，但会从生产环境列表和 Feed 中排除。
+
+设置 `pinned: true` 可将文章排在普通文章之前；如果设置了 `priority`，会优先按它排序，否则按发布日期排序。
+
+### 别名与固定链接
+
+`alias` 始终位于 `/posts/` 下：
+
+~~~yaml
+alias: "my-special-article"
+~~~
+
+`permalink` 位于站点根路径下，并且优先级高于 `alias`：
+
+~~~yaml
+permalink: "notes/my-special-article"
+~~~
+
+两者都不要包含开头或结尾的斜杠，并确保在整个站点中唯一。
+
+### 文章加密
+
+~~~yaml
+encrypted: true
+password: "use-a-strong-password"
+passwordHint: "给读者的可选提示"
+hideHomeContent: true
+~~~
+
+Mizuki 对渲染后的文章执行浏览器端解密。这不是服务端访问控制：加密内容仍会随静态站点分发，具备能力的访问者可以下载或分析它。不要用来存放凭据、私钥或高度敏感信息。加密文章不会进入 RSS 和 Atom Feed。
+
+## Markdown 与 MDX
+
+支持标准 Markdown、HTML 和 `.mdx`。如果组件属于当前项目，MDX 可以导入 Astro/Svelte 组件并使用客户端指令。
+
+### 提示块
+
+指令式提示块：
+
+~~~markdown
+:::note[可选标题]
+这是一个信息提示。
+:::
+
+:::warning{title="请注意"}
+这是一个警告。
+:::
+~~~
+
+主要类型为 `note`、`tip`、`important`、`warning` 和 `caution`；`info`、`success`、`danger`、`example` 等常见别名也会映射到可用样式。
+
+同时支持 GitHub 风格提示块：
+
+~~~markdown
+> [!NOTE]
+> 这是一个信息提示。
+
+> [!WARNING]
+> 这是一个警告。
+~~~
+
+### 代码与数学公式
+
+围栏代码块由 Expressive Code 渲染，提供语法高亮、行号、语言标签、复制按钮、代码组，以及长代码块自动折叠等功能。
+
+行内公式使用 `$...$`，独立公式使用 `$$...$$`，构建时由 KaTeX 渲染。
+
+### Mermaid 与 PlantUML
+
+Mermaid 使用 `mermaid` 代码围栏：
+
+~~~~markdown
+~~~mermaid
+graph LR
+    A[编写] --> B[构建]
+    B --> C[部署]
+~~~
+~~~~
+
+PlantUML 使用 `plantuml` 代码围栏：
+
+~~~~markdown
+~~~plantuml
+@startuml
+Alice -> Bob: Hello
+@enduml
+~~~
+~~~~
+
+PlantUML 源码会编码到图片 URL，默认发送到 `src/config/markdownConfig.ts` 配置的公共服务器。图表中不要放密码、Token、个人信息或其他机密内容；不适合公开渲染时，请使用自建服务器或关闭该功能。
+
+### GitHub 卡片、Wiki Link 与 Spoiler
+
+GitHub 仓库卡片：
+
+~~~markdown
+::github{repo="owner/repository"}
+~~~
+
+链接到另一篇文章：
+
+~~~markdown
+[[guides/getting-started]]
+[[guides/getting-started#installation|阅读安装章节]]
+~~~
+
+单独占一行的 Wiki Link 会渲染为文章卡片，行内 Wiki Link 会渲染为普通站内链接。
+
+Spoiler 只是视觉遮罩：
+
+~~~markdown
+答案是 :spoiler[隐藏文本]。
+~~~
+
+不要把 Spoiler 当作安全功能；需要密码提示时使用文章加密，并理解其静态站点限制。
+
+### 图片
+
+相对图片从当前文章目录解析，根相对路径指向 `public/`，HTTP(S) URL 用于远程图片：
+
+~~~markdown
+![本地图片](./diagram.webp)
+![公共图片](/images/posts/diagram.webp)
+![远程图片](https://example.com/image.webp)
+~~~
+
+为图片添加标题即可显示说明文字；在 alt 文本中加入 `w-N%` 可将图片宽度设置为 1% 到 100% 并居中：
+
+~~~markdown
+![架构图 w-75%](./architecture.webp "内容管线")
+~~~
+
+### 图片网格
+
+需要控制列数、宽高比或填充方式时使用 `:::grid`：
+
+~~~markdown
+:::grid{columns="3" aspect="16/9" fit="cover"}
+![第一张图片](./one.webp)
+
+![第二张图片](./two.webp)
+:::
+~~~
+
+`columns` 支持 1–6，`aspect` 必须是正数比例，`fit` 为 `cover` 或 `contain`。默认配置还会把连续的纯图片段落转换成最多四列的自动网格。每个网格拥有独立的 Fancybox 灯箱分组。
+
+### 视频嵌入
+
+在服务商允许嵌入的前提下，将其 Embed 选项提供的 iframe 粘贴到 Markdown 或 MDX 文件中。YouTube 和 Bilibili 都提供嵌入代码；除非确有需要，否则不要启用自动播放。
+
+## 仓库中的真实示例
+
+以下是 `src/content/posts/` 下的真实文章，可按主题查看具体用法。它们属于演示内容，部署个人站点前请删除或替换：
+
+| 主题 | 示例 |
+| :--- | :--- |
+| 目录式文章结构和基础文章 | [`guide/index.md`](../src/content/posts/guide/index.md) |
+| 标准 Markdown 基础语法 | [`markdown-tutorial.md`](../src/content/posts/markdown-tutorial.md) |
+| 提示块、GitHub 卡片、Wiki Link 等扩展 | [`markdown-extended.md`](../src/content/posts/markdown-extended.md) |
+| Mermaid 流程图及其他图表 | [`markdown-mermaid.md`](../src/content/posts/markdown-mermaid.md) |
+| 图片网格、标题、响应式行为和灯箱分组 | [`image-grid-demo.md`](../src/content/posts/image-grid-demo.md) |
+| YouTube 与 Bilibili iframe 嵌入 | [`video.md`](../src/content/posts/video.md) |
+| 浏览器端加密文章 | [`encrypted-post.md`](../src/content/posts/encrypted-post.md) |
+| MDX 导入、JavaScript 导出和 Astro 组件 | [`content-pipeline-fixture.mdx`](../src/content/posts/content-pipeline-fixture.mdx) |
+
+较早的演示文章可能仍展示已不属于当前 schema 的字段。新文章请以本文字段表和源代码为准。
+
+## 发布前清单
+
+1. 检查必填 frontmatter 和日期格式。
+2. 检查图片路径、文件名大小写和远程 URL。
+3. 确认每个提示块、网格、代码围栏和图表块都已闭合。
+4. 确认 alias 和 permalink 在站点中唯一。
+5. 不要把 Secret 放入 PlantUML、MDX、公共图片或文章内容。
+6. 部署个人站点前，删除或替换仓库自带的演示文章、页面数据和图片。
+
+更多渲染细节请参阅[内容渲染指南](CONTENT_RENDERING.md)；Markdown/MDX 扩展和实际文章用法也可以直接参考上述示例。

--- a/docs/CONTENT_SEPARATION.md
+++ b/docs/CONTENT_SEPARATION.md
@@ -63,7 +63,8 @@ pnpm dev
 
 | 值 | 说明 | 适用场景 |
 |---|---|---|
-| `false` 或未设置 | **禁用内容分离** (默认) | 新手、个人博客、内容较少 |
+| `false` | **禁用内容分离** | 本地内容、个人博客、内容较少 |
+| 未设置或其他值 | 启用同步逻辑 | 建议显式设置为 `false` 或 `true`，避免误解 |
 | `true` | **启用内容分离** | 团队协作、私有内容、大量文章 |
 
 ### 配置位置
@@ -104,6 +105,8 @@ git commit -m "Update content"
 git push
 ```
 
+> **注意**：本地开发时建议显式设置 `ENABLE_CONTENT_SYNC=false`。如果不设置，当前同步脚本会进入同步逻辑；没有内容仓库地址时通常会继续使用本地内容，但会输出提示。
+
 #### 场景 2: 独立仓库（分离）模式
 
 **特点**:
@@ -132,11 +135,13 @@ git commit -m "Update article"
 git push
 ```
 
+> **同步副作用**：当 `CONTENT_DIR` 已经是 Git 仓库时，同步脚本会 fetch 并将其重置到远程 `main` 或 `master` 分支。建立运行时映射时，它还可能将已有目录备份为 `.backup`、创建 junction 或复制文件，并在代码仓库中提交同步结果。运行前请提交或备份本地修改，不要直接编辑同步目标。
+
 ### 模式切换
 
 #### 从本地切换到独立仓库
 
-1. 创建内容仓库 (参考 [CONTENT_MIGRATION.md](./CONTENT_MIGRATION.md))
+1. 创建内容仓库 (参考 [MIGRATION_GUIDE.md](./MIGRATION_GUIDE.md))
 2. 编辑 `.env`:
    ```bash
    ENABLE_CONTENT_SYNC=true
@@ -367,7 +372,8 @@ CONTENT_REPO_URL=https://YOUR_TOKEN@github.com/your-username/Mizuki-Content-Priv
 |------|------|
 | `pnpm run init-content` | 运行交互式初始化向导 |
 | `pnpm run sync-content` | 手动同步内容仓库 |
-| `pnpm run check-env` | 检查环境变量配置 |
+| `pnpm run check` | 运行 Astro 诊断 |
+| `pnpm run type-check` | 运行 TypeScript 类型检查 |
 | `pnpm dev` | 启动开发服务器 (自动同步) |
 | `pnpm build` | 构建项目 (自动同步) |
 
@@ -456,7 +462,8 @@ ssh -T git@github.com
 
 4. 运行检查命令
    ```bash
-   pnpm run check-env
+   pnpm run check
+   pnpm run type-check
    ```
 
 ### 问题 5: 内容同步失败
@@ -510,7 +517,7 @@ git clone https://github.com/your-username/Mizuki-Content.git content
 
 ## 📚 相关文档
 
-- [内容迁移指南](./CONTENT_MIGRATION.md) - 如何从单仓库迁移到分离模式
+- [内容迁移指南](./MIGRATION_GUIDE.md) - 如何从单仓库迁移到分离模式
 - [内容仓库结构](./CONTENT_REPOSITORY.md) - 内容仓库的推荐结构
 - [主 README](../README.zh.md) - 项目总体说明
 
@@ -520,6 +527,6 @@ git clone https://github.com/your-username/Mizuki-Content.git content
 
 - 查看 [GitHub Issues](https://github.com/LyraVoid/Mizuki/issues)
 - 阅读 [完整文档](../README.zh.md)
-- 运行 `pnpm run check-env` 检查配置
+- 运行 `pnpm run check` 和 `pnpm run type-check` 检查项目
 
 祝你使用愉快! 🎉

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,16 @@
   - 功能特性
   - 基础配置
   - 常见问题
+- **[CONTENT_AUTHORING.md](./CONTENT_AUTHORING.md)** - English content authoring guide
+- **[CONTENT_AUTHORING.zh.md](./CONTENT_AUTHORING.zh.md)** - 简体中文内容编写指南
+- **[CONTENT_AUTHORING.ja.md](./CONTENT_AUTHORING.ja.md)** - 日本語コンテンツ執筆ガイド
+- **[CONTENT_AUTHORING.tw.md](./CONTENT_AUTHORING.tw.md)** - 繁體中文內容編寫指南
+
+所有版本均包括：
+
+  - Frontmatter 字段与示例
+  - Markdown/MDX 扩展
+  - 图片、图表、视频和文章加密
 
 ### 多语言文档
 
@@ -85,6 +95,7 @@
 ```
 docs/
 ├── README.md                    # 本文档 - 索引导航
+├── CONTENT_AUTHORING*.md        # 多语言 Frontmatter 与 Markdown/MDX 写作指南
 ├── CONTENT_RENDERING.md         # Markdown/MDX 与 Feed 渲染
 ├── CONTENT_SEPARATION.md        # 内容分离核心指南
 ├── CONTENT_REPOSITORY.md        # 内容仓库结构
@@ -111,6 +122,6 @@ docs/
 
 - 查看 [GitHub Issues](https://github.com/LyraVoid/Mizuki/issues)
 - 阅读相关文档的故障排查章节
-- 运行 `pnpm run check-env` 检查配置
+- 运行 `pnpm run check` 和 `pnpm run type-check` 检查项目
 
 祝你使用愉快！🎉

--- a/src/content/posts/content-pipeline-fixture.mdx
+++ b/src/content/posts/content-pipeline-fixture.mdx
@@ -17,7 +17,7 @@ export const componentMessage = "This panel is rendered by an imported Astro com
 
 MDX lets you write familiar Markdown while adding components and JavaScript
 expressions where ordinary Markdown is not enough. This guide introduces the
-syntax that is most useful when authoring an article in Mizuki.
+syntax that is most useful when authoring an article in a content-driven Astro site.
 
 :::note[What is MDX?]
 An `.mdx` file is still a Markdown document. Headings, lists, links, images,
@@ -114,7 +114,7 @@ This content is emphasized as a tip.
 ## Wiki Links
 
 An inline Wiki Link points to another article while keeping the sentence
-readable. For example, continue with [[guide|the Mizuki guide]].
+readable. For example, continue with [[guide|the content guide]].
 
 A standalone Wiki Link becomes an article card with its available metadata and
 cover image:
@@ -122,7 +122,7 @@ cover image:
 [[guide]]
 
 ```markdown
-Read [[guide|the Mizuki guide]] for more details.
+Read [[guide|the content guide]] for more details.
 
 [[guide]]
 ```
@@ -199,11 +199,11 @@ Relative links and absolute URLs that use the configured site origin are
 classified as internal. Links to other origins receive the external-link
 attributes configured by the theme.
 
-- Visit the [About page using an absolute site URL](https://mizuki.mysqil.com/about/).
+- Visit the [About page using a relative site URL](/about/).
 - Compare it with an [external reference](https://example.com/reference).
 
-You can normally use a relative path for internal content; the absolute example
-above simply demonstrates that both forms receive the same classification.
+Use relative paths for internal content. External origins such as
+https://example.com/ are classified separately by the theme.
 
 ## Writing Portable MDX
 

--- a/src/content/posts/encrypted-post.md
+++ b/src/content/posts/encrypted-post.md
@@ -1,18 +1,18 @@
 ---
 title: Encrypted Post
 published: 2024-01-15
-description: This is an article for testing the page encryption feature
+description: A generic example of browser-side post encryption.
 encrypted: true
-pinned: true
+pinned: false
 password: "123456"
 passwordHint: "123456"
 hideHomeContent: true
 alias: "encrypted-example"
-tags: ["Test", "Encryption"]
-category: "Technology"
+tags: ["Example", "Encryption"]
+category: "Examples"
 ---
 
-This blog template is built with [Astro](https://astro.build/). For the things that are not mentioned in this guide, you may find the answers in the [Astro Docs](https://docs.astro.build/).
+This article demonstrates browser-side password protection. The password is intentionally present in the repository so readers can open the example; never reuse it for private content.
 
 ## Front-matter of Posts
 

--- a/src/content/posts/guide/index.md
+++ b/src/content/posts/guide/index.md
@@ -1,28 +1,30 @@
 ---
-title: Simple Guides for Mizuki
+title: "Writing a Blog Post"
 published: 2024-04-01
-description: "How to use this blog template."
+description: "A generic example of article structure and frontmatter."
 image: "./cover.webp"
-tags: ["Mizuki", "Blogging", "Customization"]
+tags: ["Example", "Writing", "Markdown"]
 category: Guides
 draft: false
 ---
 
 
 
-This blog template is built with [Astro](https://astro.build/). For the things that are not mentioned in this guide, you may find the answers in the [Astro Docs](https://docs.astro.build/).
+This blog template is built with [Astro](https://astro.build/). This article is a small, generic example of the file structure and common frontmatter used by a post. The complete current schema and Markdown syntax are maintained in the [Content Authoring Guide](../../../../docs/CONTENT_AUTHORING.md).
 
-## Front-matter of Posts
+## Common frontmatter
 
 ```yaml
 ---
-title: My First Blog Post
-published: 2023-09-09
-description: This is the first post of my new Astro blog.
-image: ./cover.jpg
-tags: [Foo, Bar]
-category: Front-end
+title: "An Example Article"
+published: 2026-08-01
+updated: 2026-08-08
+description: "A short summary for previews."
+image: ./cover.webp
+tags: [Example, Guide]
+category: Guides
 draft: false
+comment: true
 ---
 ```
 
@@ -48,12 +50,13 @@ draft: false
 
 
 
-Your post files should be placed in `src/content/posts/` directory. You can also create sub-directories to better organize your posts and assets.
+Place post files in `src/content/posts/`. You can create sub-directories to organize articles and their local assets.
 
 ```
 src/content/posts/
-├── post-1.md
-└── post-2/
+├── example.md
+└── guides/
     ├── cover.webp
     └── index.md
 ```
+Relative images such as `./cover.webp` are resolved from the current article file.

--- a/src/content/posts/markdown-extended.md
+++ b/src/content/posts/markdown-extended.md
@@ -227,6 +227,12 @@ Only widths from `w-1%` through `w-100%` are accepted. Remote image hosts in
 in the initial HTML. Add `data-no-enhance` to a raw HTML image or ancestor when
 custom markup should be left alone.
 
+```html
+<div data-no-enhance>
+  <img src="/images/demos/image-grid-demo/square-3.webp" alt="Custom image markup" width="640" height="360">
+</div>
+```
+
 ## Automatic Image Grids
 
 Two or more adjacent standalone images are grouped into a responsive gallery.

--- a/src/content/posts/video.md
+++ b/src/content/posts/video.md
@@ -9,7 +9,7 @@ draft: false
 
 Just copy the embed code from YouTube or other platforms, and paste it in the markdown file.
 
-```yaml
+```markdown
 ---
 title: Include Video in the Post
 published: 2023-10-19
@@ -24,4 +24,6 @@ published: 2023-10-19
 
 ## Bilibili
 
-<iframe width="100%" height="468" src="//player.bilibili.com/player.html?bvid=BV1fK4y1s7Qf&p=1&autoplay=0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" &autoplay=0> </iframe>
+<iframe width="100%" height="468" src="//player.bilibili.com/player.html?bvid=BV1fK4y1s7Qf&p=1&autoplay=0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true"></iframe>
+
+Keep autoplay settings in the iframe URL query string; do not add query parameters as standalone HTML attributes.


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other: documentation and example content maintenance

## Checklist

- [x] I have read the contribution guidance referenced by the repository template.
- [x] I have checked to ensure that this Pull Request is not for personal-only changes.
- [x] I have performed a self-review of my own changes.
- [ ] I have run the repository checks; intentionally not run for this documentation-only request.

## Related Issue

Closes #545

## Changes

- Refresh the English, Simplified Chinese, Japanese, and Traditional Chinese README content-authoring entry points.
- Add multilingual content-authoring guides covering current Frontmatter, Markdown/MDX extensions, media, diagrams, encryption limits, synchronization caveats, and publishing reminders.
- Link the guides to real examples under `src/content/posts/`, including standard Markdown, extensions, Mermaid, image grids, video, encryption, folder-based posts, and MDX.
- Update example posts with a current generic folder/frontmatter example, a valid video embed example, an explicit browser-side encryption demo with the repository's public demo credential, a generic MDX link example, and a `data-no-enhance` demonstration.
- Keep the extension showcase article's Mizuki-specific values so it remains a project feature demonstration.
- No runtime theme code was changed.

## How To Test

Per request, no checks, tests, or builds were run. I performed a read-only review of the documentation and content diffs.

## Screenshots (if applicable)

Not applicable; this PR changes documentation and demo content only.

## Additional Notes

The repository's existing demo posts, page data, albums, and images are still demo content and should be removed or replaced before deploying a personal site.