### PR TITLE
feat(layout): 优化 2K/4K 超宽屏文章布局、宽内容轨道与 TOC 策略

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -43,6 +43,7 @@ import { remarkContent } from "./src/plugins/remark-content.mjs";
 import { parseDirectiveNode } from "./src/plugins/remark-directive-rehype.js";
 import { remarkEscapeNumericColons } from "./src/plugins/remark-escape-numeric-colons.mjs";
 import { remarkFixGithubAdmonitions } from "./src/plugins/remark-fix-github-admonitions.js";
+import { remarkMarkSectionized } from "./src/plugins/remark-mark-sectionized.mjs";
 import { remarkMermaid } from "./src/plugins/remark-mermaid.js";
 import { remarkPlantuml } from "./src/plugins/remark-plantuml.mjs";
 import { remarkWikiLink } from "./src/plugins/remark-wiki-link.mjs";
@@ -236,6 +237,7 @@ export default defineConfig({
 				remarkMermaid,
 				[remarkPlantuml, markdownConfig.plantuml],
 				remarkSectionize,
+				remarkMarkSectionized,
 			],
 			rehypePlugins: [
 				rehypeKatex,

--- a/src/components/features/settings/SettingsPanel.svelte
+++ b/src/components/features/settings/SettingsPanel.svelte
@@ -15,6 +15,7 @@ import {
 	getDefaultOverlayCardOpacity,
 	getDefaultOverlayOpacity,
 	getDefaultSakuraEnabled,
+	getDefaultUltrawidePostLayout,
 	getDefaultWavesEnabled,
 	getHue,
 	getStoredBannerTitleEnabled,
@@ -22,6 +23,7 @@ import {
 	getStoredOverlayCardOpacity,
 	getStoredOverlayOpacity,
 	getStoredSakuraEnabled,
+	getStoredUltrawidePostLayout,
 	getStoredWallpaperMode,
 	getStoredWavesEnabled,
 	setBannerTitleEnabled,
@@ -30,6 +32,7 @@ import {
 	setOverlayCardOpacity,
 	setOverlayOpacity,
 	setSakuraEnabled,
+	setUltrawidePostLayout,
 	setWallpaperMode,
 	setWavesEnabled,
 } from "@utils/setting-utils";
@@ -80,6 +83,9 @@ const hasBannerSettings = isWavesSwitchable || isBannerTitleSwitchable;
 const isSakuraSwitchable =
 	sakuraConfig.enable && (sakuraConfig.switchable ?? false);
 
+const isUltrawidePostLayoutSwitchable =
+	siteConfig.ultrawidePostLayout?.allowSwitch ?? true;
+
 const showModeValue = siteConfig.wallpaperMode.showModeSwitchOnMobile;
 let isMobile = $state(false);
 
@@ -97,7 +103,8 @@ const hasAnyContent = $derived(
 		allowLayoutSwitch ||
 		hasOverlaySettings ||
 		hasBannerSettings ||
-		isSakuraSwitchable,
+		isSakuraSwitchable ||
+		isUltrawidePostLayoutSwitchable,
 );
 
 let hue = $state(getHue());
@@ -116,6 +123,7 @@ let bannerTitleEnabled = $state(getDefaultBannerTitleEnabled());
 const defaultBannerTitleEnabled = getDefaultBannerTitleEnabled();
 let sakuraEnabled = $state(getDefaultSakuraEnabled());
 const defaultSakuraEnabled = getDefaultSakuraEnabled();
+let ultrawidePostLayout = $state(getDefaultUltrawidePostLayout());
 
 let overlaySettingsIsDefault = $derived(
 	(!isOverlayOpacitySwitchable || overlayOpacity === defaultOverlayOpacity) &&
@@ -198,6 +206,11 @@ function toggleSakuraEnabled() {
 	setSakuraEnabled(sakuraEnabled);
 }
 
+function toggleUltrawidePostLayout() {
+	ultrawidePostLayout = !ultrawidePostLayout;
+	setUltrawidePostLayout(ultrawidePostLayout);
+}
+
 function switchWallpaperMode(newMode: WALLPAPER_MODE) {
 	wallpaperMode = newMode;
 	setWallpaperMode(newMode);
@@ -248,6 +261,7 @@ onMount(() => {
 	wavesEnabled = getStoredWavesEnabled();
 	bannerTitleEnabled = getStoredBannerTitleEnabled();
 	sakuraEnabled = getStoredSakuraEnabled();
+	ultrawidePostLayout = getStoredUltrawidePostLayout();
 
 	const savedLayout = siteConfig.postListLayout?.enable
 		? sessionStorage.getItem("postListLayout") ||
@@ -638,6 +652,38 @@ $effect(() => {
 					{#if currentLayout === "grid"}
 						<Icon icon="material-symbols:check-circle" class="text-[1rem] shrink-0 text-(--primary)" />
 					{/if}
+				</button>
+			</div>
+		</div>
+	{/if}
+
+	{#if isUltrawidePostLayoutSwitchable}
+		<div class="mt-2 mb-2">
+			<div
+				class="flex gap-2 font-bold text-lg text-neutral-900 dark:text-neutral-100 transition relative ml-3 mb-2
+				before:w-1 before:h-4 before:rounded-md before:bg-(--primary)
+				before:absolute before:-left-3 before:top-1/2 before:-translate-y-1/2"
+			>
+				{i18n(I18nKey.settingsFeatures)}
+			</div>
+			<div class="space-y-1">
+				<button
+					class="w-full btn-regular rounded-md py-2 px-3 flex items-center gap-3 text-left active:scale-95 transition-all relative overflow-hidden"
+					class:bg-(--btn-regular-bg-hover)={ultrawidePostLayout}
+					onclick={toggleUltrawidePostLayout}
+				>
+					<Icon icon="material-symbols:width-wide-outline" class="text-[1.25rem] shrink-0" />
+					<span class="flex-1">
+						<span class="block text-sm">{i18n(I18nKey.ultrawidePostLayout)}</span>
+						<span class="block text-xs opacity-60">{i18n(I18nKey.ultrawidePostLayoutHint)}</span>
+					</span>
+					<div class="w-10 h-5 rounded-full transition-all duration-200 relative"
+						class:bg-(--primary)={ultrawidePostLayout}
+						class:bg-(--btn-regular-bg-active)={!ultrawidePostLayout}>
+						<div class="absolute top-0.5 w-4 h-4 bg-white rounded-full shadow transition-all duration-200"
+							class:left-0.5={!ultrawidePostLayout}
+							class:left-5={ultrawidePostLayout}></div>
+					</div>
 				</button>
 			</div>
 		</div>

--- a/src/components/misc/Markdown.astro
+++ b/src/components/misc/Markdown.astro
@@ -1,6 +1,7 @@
 ---
 import "@/styles/markdown.css";
 import "@/styles/markdown-extend.styl";
+import "@/styles/post-content-rails.css";
 
 interface Props {
 	class: string;

--- a/src/components/organisms/navigation/Navbar.astro
+++ b/src/components/organisms/navigation/Navbar.astro
@@ -99,7 +99,7 @@ const iconWebpSrc = hasIconPngFallback
 ---
 <div id="navbar" class="z-50 onload-animation group" data-transparent-mode={navbarTransparentMode} data-is-home={isHomePage}>
     <div class="absolute h-8 left-0 right-0 -top-8 bg-[var(--card-bg)] transition"></div> <!-- used for onload animation -->
-    <div class:list={[className, "!overflow-visible max-w-[var(--page-width)] h-[4.5rem] mx-auto flex items-center justify-between px-4"]}>
+    <div class:list={[className, "!overflow-visible max-w-[var(--layout-page-width)] h-[4.5rem] mx-auto flex items-center justify-between px-4"]}>
         <a href={url('/')} class="btn-plain scale-animation rounded-lg h-[2.5rem] md:h-[3.25rem] md:[.enable-banner_&]:h-[2.5rem] md:[.enable-banner_&]:group-[.scrolled]:h-[3.25rem] px-5 font-bold active:scale-95 shrink-0 transition-all duration-300">
             <div class="flex flex-row items-center text-md">
 				{/* 使用navbarTitle配置或默认配置 */}

--- a/src/components/widgets/card-toc/CardTOC.astro
+++ b/src/components/widgets/card-toc/CardTOC.astro
@@ -22,6 +22,7 @@ interface Props {
 
 const { class: className, style } = Astro.props;
 const useJapaneseBadge = siteConfig.toc.useJapaneseBadge;
+const tocDepth = siteConfig.toc.depth;
 ---
 
 <WidgetLayout
@@ -30,7 +31,11 @@ const useJapaneseBadge = siteConfig.toc.useJapaneseBadge;
 	class={"group " + (className || "")}
 	style={style}
 >
-	<div data-card-toc-root data-japanese-badge={String(useJapaneseBadge)}>
+	<div
+		data-card-toc-root
+		data-depth={String(tocDepth)}
+		data-japanese-badge={String(useJapaneseBadge)}
+	>
 		<div class="toc-scroll-container">
 			<div class="toc-content" data-card-toc-content></div>
 		</div>
@@ -81,10 +86,14 @@ const useJapaneseBadge = siteConfig.toc.useJapaneseBadge;
 			}
 
 			const useJapaneseBadge = root.dataset.japaneseBadge === "true";
+			const configuredDepth = Number.parseInt(root.dataset.depth || "", 10);
+			const maxLevel = Number.isFinite(configuredDepth)
+				? configuredDepth
+				: 3;
 
 			const manager = new TOCManager({
 				contentElement: tocContent,
-				maxLevel: 3,
+				maxLevel,
 				useJapaneseBadge,
 				scrollOffset: 80,
 			});

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -93,6 +93,14 @@ export const siteConfig: SiteConfig = {
 		},
 	},
 
+	// 文章页超宽屏布局配置
+	// 在 2K/4K 视口下扩展文章容器、侧栏与正文阅读轨道；1920px 以下不生效。
+	// 与 pageScaling 互不影响：断点按 CSS 视口判断，且 pageScaling 在 2000px 以上是空操作。
+	ultrawidePostLayout: {
+		enable: true, // 访客未手动切换时的初始状态
+		allowSwitch: true, // 是否在设置面板中显示开关
+	},
+
 	// 标签样式配置
 	tagStyle: {
 		// 是否使用新样式（悬停高亮样式）还是旧样式（外框常亮样式）

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -42,9 +42,9 @@ export const siteConfig: SiteConfig = {
 		logo: "assets/home/default-logo.webp",
 	},
 
-	// 页面自动缩放配置
+	// 旧版页面自动缩放配置。默认关闭，页面尺寸优先交由响应式布局处理。
 	pageScaling: {
-		enable: true, // 是否开启自动缩放
+		enable: false, // 兼容旧站点的可选缩放；不建议通过根字号控制整体布局
 		targetWidth: 2000, // 目标宽度，低于此宽度时开始缩放
 	},
 

--- a/src/i18n/i18nKey.ts
+++ b/src/i18n/i18nKey.ts
@@ -317,6 +317,8 @@ enum I18nKey {
 	postListLayout = "postListLayout",
 	postListLayoutList = "postListLayoutList",
 	postListLayoutGrid = "postListLayoutGrid",
+	ultrawidePostLayout = "ultrawidePostLayout",
+	ultrawidePostLayoutHint = "ultrawidePostLayoutHint",
 	resetAll = "resetAll",
 	settingsThemeColor = "settingsThemeColor",
 	settingsWallpaper = "settingsWallpaper",
@@ -324,6 +326,7 @@ enum I18nKey {
 	settingsBanner = "settingsBanner",
 	settingsEffects = "settingsEffects",
 	settingsLayout = "settingsLayout",
+	settingsFeatures = "settingsFeatures",
 
 	// 站点统计
 	siteStats = "siteStats",

--- a/src/i18n/languages/en.ts
+++ b/src/i18n/languages/en.ts
@@ -235,6 +235,8 @@ export const en: Translation = {
 	[Key.postListLayout]: "Post Layout",
 	[Key.postListLayoutList]: "List",
 	[Key.postListLayoutGrid]: "Grid",
+	[Key.ultrawidePostLayout]: "Wide Screen Layout",
+	[Key.ultrawidePostLayoutHint]: "Widens articles on 2K and larger screens",
 	[Key.resetAll]: "Reset All",
 	[Key.settingsThemeColor]: "Theme Color",
 	[Key.settingsWallpaper]: "Wallpaper",
@@ -242,6 +244,7 @@ export const en: Translation = {
 	[Key.settingsBanner]: "Banner Options",
 	[Key.settingsEffects]: "Effects",
 	[Key.settingsLayout]: "Layout",
+	[Key.settingsFeatures]: "Features",
 
 	// Skills Page
 	[Key.skills]: "Skills",

--- a/src/i18n/languages/ja.ts
+++ b/src/i18n/languages/ja.ts
@@ -237,6 +237,8 @@ export const ja: Translation = {
 	[Key.postListLayout]: "投稿レイアウト",
 	[Key.postListLayoutList]: "リスト",
 	[Key.postListLayoutGrid]: "グリッド",
+	[Key.ultrawidePostLayout]: "ワイド記事レイアウト",
+	[Key.ultrawidePostLayoutHint]: "2K 以上の画面で記事を広げます",
 	[Key.resetAll]: "すべてリセット",
 	[Key.settingsThemeColor]: "テーマカラー",
 	[Key.settingsWallpaper]: "壁紙",
@@ -244,6 +246,7 @@ export const ja: Translation = {
 	[Key.settingsBanner]: "バナーオプション",
 	[Key.settingsEffects]: "エフェクト",
 	[Key.settingsLayout]: "レイアウト",
+	[Key.settingsFeatures]: "機能",
 
 	// スキルページ
 	[Key.skills]: "スキル",

--- a/src/i18n/languages/zh_CN.ts
+++ b/src/i18n/languages/zh_CN.ts
@@ -325,6 +325,8 @@ export const zh_CN: Translation = {
 	[Key.postListLayout]: "文章布局",
 	[Key.postListLayoutList]: "列表",
 	[Key.postListLayoutGrid]: "网格",
+	[Key.ultrawidePostLayout]: "宽屏文章布局",
+	[Key.ultrawidePostLayoutHint]: "在 2K 及以上视口加宽文章页",
 	[Key.resetAll]: "全部重置",
 	[Key.settingsThemeColor]: "主题色",
 	[Key.settingsWallpaper]: "壁纸",
@@ -332,6 +334,7 @@ export const zh_CN: Translation = {
 	[Key.settingsBanner]: "横幅选项",
 	[Key.settingsEffects]: "特效",
 	[Key.settingsLayout]: "布局",
+	[Key.settingsFeatures]: "功能",
 
 	// 站点统计
 	[Key.siteStats]: "站点统计",

--- a/src/i18n/languages/zh_TW.ts
+++ b/src/i18n/languages/zh_TW.ts
@@ -327,6 +327,8 @@ export const zh_TW: Translation = {
 	[Key.postListLayout]: "文章佈局",
 	[Key.postListLayoutList]: "列表",
 	[Key.postListLayoutGrid]: "網格",
+	[Key.ultrawidePostLayout]: "寬屏文章佈局",
+	[Key.ultrawidePostLayoutHint]: "在 2K 及以上視口加寬文章頁",
 	[Key.resetAll]: "全部重置",
 	[Key.settingsThemeColor]: "主題色",
 	[Key.settingsWallpaper]: "壁紙",
@@ -334,6 +336,7 @@ export const zh_TW: Translation = {
 	[Key.settingsBanner]: "橫幅選項",
 	[Key.settingsEffects]: "特效",
 	[Key.settingsLayout]: "佈局",
+	[Key.settingsFeatures]: "功能",
 
 	// 站點統計
 	[Key.siteStats]: "站點統計",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -38,6 +38,7 @@ interface Props {
 	setOGTypeArticle?: boolean;
 	postSlug?: string;
 	coverImage?: string;
+	layoutVariant?: "default" | "home" | "post";
 }
 
 let {
@@ -48,6 +49,7 @@ let {
 	setOGTypeArticle,
 	postSlug,
 	coverImage,
+	layoutVariant = "default",
 } = Astro.props;
 
 // defines global css variables
@@ -150,6 +152,7 @@ const bannerOffset =
 	data-waves-config-enabled={siteConfig.banner?.waves?.enable ? "true" : "false"}
 	data-banner-title-config-enabled={siteConfig.banner?.homeText?.enable ? "true" : "false"}
 	data-post-list-layout-enabled={siteConfig.postListLayout?.enable ? "true" : "false"}
+	data-layout-variant={layoutVariant}
 >
 	<head>
 		<meta charset="UTF-8" />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -20,6 +20,7 @@ import "../styles/main.css";
 import "../styles/banner.css";
 import "../styles/transition.css";
 import "../styles/widget-responsive.css";
+import "../styles/layout-responsive.css";
 import "../styles/mobile-navbar.css";
 import "../styles/wallpaper-navbar-transparent.css";
 import "../styles/fancybox-custom.css";

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -154,6 +154,7 @@ const bannerOffset =
 	data-banner-title-config-enabled={siteConfig.banner?.homeText?.enable ? "true" : "false"}
 	data-post-list-layout-enabled={siteConfig.postListLayout?.enable ? "true" : "false"}
 	data-layout-variant={layoutVariant}
+	data-ultrawide-post={siteConfig.ultrawidePostLayout?.enable ? "true" : "false"}
 >
 	<head>
 		<meta charset="UTF-8" />

--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -65,6 +65,7 @@ const hasBannerLink = !!siteConfig.banner.credit.url;
 
 // 检查是否为首页
 const isHomePage = Astro.url.pathname === "/" || Astro.url.pathname === "";
+const layoutVariant = postSlug ? "post" : isHomePage ? "home" : "default";
 // 手机端非首页不显示banner的CSS类
 const mobileNonHomeBannerClass = !isHomePage ? "mobile-hide-banner" : "";
 
@@ -111,6 +112,7 @@ const defaultPostListLayout = siteConfig.postListLayout?.defaultMode || "list";
 	setOGTypeArticle={setOGTypeArticle}
 	postSlug={postSlug}
 	coverImage={coverImage}
+	layoutVariant={layoutVariant}
 >
 	<GridScripts
 		navbarTransparentMode={siteConfig.banner?.navbar?.transparentMode ||
@@ -165,6 +167,7 @@ const defaultPostListLayout = siteConfig.postListLayout?.defaultMode || "list";
 				id="main-grid"
 				class={`transition duration-700 w-full left-0 right-0 grid ${gridCols} grid-rows-none md:grid-rows-[auto] mx-auto gap-4 px-2 md:px-4 ${!mobileShowSidebar || !hasMobileDrawerComponents ? "mobile-no-sidebar" : ""} ${hasRightSidebarComponents ? "mobile-both-sidebar" : ""}`}
 				data-layout-mode={defaultPostListLayout}
+				data-layout-variant={layoutVariant}
 			>
 				<!-- Banner image credit -->
 				{

--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -286,12 +286,12 @@ const defaultPostListLayout = siteConfig.postListLayout?.defaultMode || "list";
 	<!-- 侧边栏TOC模式 -->
 	{
 		siteConfig.toc.enable && siteConfig.toc.desktopSidebar && (
-			<div class="absolute w-full z-0 hidden 2xl:block">
+			<div class="absolute w-full z-0 hidden xl:block">
 				<div class="relative max-w-(--layout-page-width) mx-auto">
 					<div
 						id="toc-wrapper"
 						class:list={[
-							"hidden lg:block transition absolute top-0 w-(--toc-width) items-center",
+							"hidden xl:block transition absolute top-0 w-(--toc-width) items-center",
 							"-right-(--toc-width)",
 							{
 								"toc-hide":

--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -137,7 +137,7 @@ const defaultPostListLayout = siteConfig.postListLayout?.defaultMode || "list";
 	<slot slot="head" name="head" />
 	<div
 		id="top-row"
-		class="z-50 pointer-events-none relative transition-all duration-700 max-w-(--page-width) px-0 md:px-4 mx-auto"
+		class="z-50 pointer-events-none relative transition-all duration-700 max-w-(--layout-page-width) px-0 md:px-4 mx-auto"
 		class:list={[""]}
 	>
 		<div
@@ -162,7 +162,7 @@ const defaultPostListLayout = siteConfig.postListLayout?.defaultMode || "list";
 		style={`top: ${finalMainPanelTop}`}
 	>
 		<!-- The pointer-events-none here prevent blocking the click event of the TOC -->
-		<div class="relative max-w-(--page-width) mx-auto pointer-events-auto">
+		<div class="relative max-w-(--layout-page-width) mx-auto pointer-events-auto">
 			<div
 				id="main-grid"
 				class={`transition duration-700 w-full left-0 right-0 grid ${gridCols} grid-rows-none md:grid-rows-[auto] mx-auto gap-4 px-2 md:px-4 ${!mobileShowSidebar || !hasMobileDrawerComponents ? "mobile-no-sidebar" : ""} ${hasRightSidebarComponents ? "mobile-both-sidebar" : ""}`}
@@ -287,7 +287,7 @@ const defaultPostListLayout = siteConfig.postListLayout?.defaultMode || "list";
 	{
 		siteConfig.toc.enable && siteConfig.toc.desktopSidebar && (
 			<div class="absolute w-full z-0 hidden 2xl:block">
-				<div class="relative max-w-(--page-width) mx-auto">
+				<div class="relative max-w-(--layout-page-width) mx-auto">
 					<div
 						id="toc-wrapper"
 						class:list={[

--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -119,7 +119,6 @@ const defaultPostListLayout = siteConfig.postListLayout?.defaultMode || "list";
 		defaultPostListLayout={siteConfig.postListLayout?.defaultMode || "list"}
 		BANNER_HEIGHT={BANNER_HEIGHT}
 		BANNER_HEIGHT_FULLSCREEN={BANNER_HEIGHT_FULLSCREEN}
-		pageScaling={siteConfig.pageScaling}
 		wavesEnabled={siteConfig.banner?.waves?.enable ?? true}
 		bannerTitleEnabled={siteConfig.banner?.homeText?.enable ?? true}
 		wallpaperEnabled={fullscreenWallpaperConfig.enable ?? true}

--- a/src/layouts/partials/GridScripts.astro
+++ b/src/layouts/partials/GridScripts.astro
@@ -10,7 +10,6 @@ interface Props {
 	defaultPostListLayout?: string;
 	BANNER_HEIGHT?: number;
 	BANNER_HEIGHT_FULLSCREEN?: number;
-	pageScaling?: { enable: boolean; targetWidth?: number };
 	wavesEnabled?: boolean;
 	bannerTitleEnabled?: boolean;
 	wallpaperEnabled?: boolean;
@@ -23,7 +22,6 @@ const {
 	defaultPostListLayout = "list",
 	BANNER_HEIGHT = 35,
 	BANNER_HEIGHT_FULLSCREEN = 100,
-	pageScaling = { enable: false },
 	wavesEnabled = true,
 	bannerTitleEnabled = true,
 	wallpaperEnabled = true,
@@ -40,7 +38,6 @@ const {
 		defaultPostListLayout,
 		BANNER_HEIGHT,
 		BANNER_HEIGHT_FULLSCREEN,
-		pageScaling,
 		wavesEnabled,
 		bannerTitleEnabled,
 		wallpaperEnabled,

--- a/src/layouts/partials/GridScripts.astro
+++ b/src/layouts/partials/GridScripts.astro
@@ -57,6 +57,37 @@ const {
 		return Number.isFinite(parsed) ? parsed : fallback;
 	}
 
+	function syncLayoutVariant() {
+		const pageData = document.getElementById("page-overlay-data");
+		let layoutVariant = "default";
+
+		if (pageData?.dataset.isPost === "true") {
+			layoutVariant = "post";
+		} else if (pageData?.dataset.isHome === "true") {
+			layoutVariant = "home";
+		}
+
+		document.documentElement.dataset.layoutVariant = layoutVariant;
+
+		const mainGrid = document.getElementById("main-grid");
+		if (mainGrid) {
+			mainGrid.dataset.layoutVariant = layoutVariant;
+		}
+
+		return layoutVariant;
+	}
+
+	function getCurrentPostListLayout() {
+		if (document.documentElement.dataset.layoutVariant === "post") {
+			return "list";
+		}
+
+		const savedLayout = postListLayoutEnabled
+			? localStorage.getItem("postListLayout")
+			: null;
+		return savedLayout || defaultPostListLayout;
+	}
+
 	function syncMainContentPosition(mode) {
 		const mainContent = document.querySelector(
 			".absolute.w-full.z-30.pointer-events-none",
@@ -203,6 +234,7 @@ const {
 		// 立即调整主内容区域位置和布局模式（避免闪烁和位置错误）
 		// 使用 requestAnimationFrame 确保 DOM 准备好
 		requestAnimationFrame(function () {
+			syncLayoutVariant();
 			const mainContent = document.querySelector(
 				".absolute.w-full.z-30.pointer-events-none",
 			);
@@ -213,8 +245,7 @@ const {
 			// 立即应用布局模式，避免闪烁
 			const mainGrid = document.getElementById("main-grid");
 			if (mainGrid) {
-				const savedLayout = postListLayoutEnabled ? localStorage.getItem("postListLayout") : null;
-				const currentLayout = savedLayout || defaultPostListLayout;
+				const currentLayout = getCurrentPostListLayout();
 				mainGrid.setAttribute("data-layout-mode", currentLayout);
 
 				// 根据布局模式显示或隐藏右侧边栏
@@ -472,16 +503,17 @@ const {
 	// 支持 Swup 页面过渡 - 在内容替换之前就应用布局，避免闪烁
 	// 支持 Swup 页面过渡
 	document.addEventListener("swup:page:view", function () {
+		syncLayoutVariant();
 		applyWallpaperMode();
 	});
 
 	// 在页面完全加载后，再次确认布局模式是否正确
 	if (document.readyState === "loading") {
 		document.addEventListener("DOMContentLoaded", function () {
+			syncLayoutVariant();
 			const mainGrid = document.getElementById("main-grid");
 			if (mainGrid) {
-				const savedLayout = postListLayoutEnabled ? localStorage.getItem("postListLayout") : null;
-				const currentLayout = savedLayout || defaultPostListLayout;
+				const currentLayout = getCurrentPostListLayout();
 				mainGrid.setAttribute("data-layout-mode", currentLayout);
 
 				if (currentLayout === "grid") {

--- a/src/layouts/partials/GridScripts.astro
+++ b/src/layouts/partials/GridScripts.astro
@@ -78,10 +78,6 @@ const {
 	}
 
 	function getCurrentPostListLayout() {
-		if (document.documentElement.dataset.layoutVariant === "post") {
-			return "list";
-		}
-
 		const savedLayout = postListLayoutEnabled
 			? localStorage.getItem("postListLayout")
 			: null;

--- a/src/layouts/partials/HeadTags.astro
+++ b/src/layouts/partials/HeadTags.astro
@@ -147,45 +147,41 @@ const favicons: Favicon[] =
 		`${offset}px`,
 	);
 
-	// 自动缩放逻辑 (Moved from MainGridLayout to here for earlier execution)
+	// 兼容旧配置的可选页面缩放。默认布局不再依赖根字号缩放。
 	(function () {
-		if (pageScaling && pageScaling.enable) {
-			function adjustPageScale() {
-				const isTouch =
-					(window.matchMedia &&
-						(window.matchMedia("(pointer:coarse)").matches ||
-							window.matchMedia("(hover: none)").matches)) ||
-					"ontouchstart" in window;
-				const isPortrait =
-					window.matchMedia &&
-					window.matchMedia("(orientation: portrait)").matches;
-				const isTabletLike = isTouch || window.innerWidth <= 1280;
-				if (isTabletLike || isPortrait) {
-					document.documentElement.style.fontSize = "";
-					return;
-				}
-				const targetWidth = pageScaling.targetWidth || 2000;
-				const currentWidth = document.documentElement.clientWidth;
-				let scale = currentWidth / targetWidth;
-				if (scale > 1) {
-					scale = 1;
-				}
-				if (scale < 0.85) {
-					scale = 0.85;
-				}
-				document.documentElement.style.fontSize = `${scale * 100}%`;
+		const root = document.documentElement;
+		if (!pageScaling || !pageScaling.enable) {
+			root.style.removeProperty("font-size");
+			return;
+		}
+
+		function adjustPageScale() {
+			const isTouch =
+				(window.matchMedia &&
+					(window.matchMedia("(pointer:coarse)").matches ||
+						window.matchMedia("(hover: none)").matches)) ||
+				"ontouchstart" in window;
+			const isPortrait =
+				window.matchMedia &&
+				window.matchMedia("(orientation: portrait)").matches;
+			if (isTouch || isPortrait) {
+				root.style.removeProperty("font-size");
+				return;
 			}
 
-			// 立即执行一次
-			adjustPageScale();
-
-			// 监听窗口大小变化
-			window.addEventListener("resize", adjustPageScale);
-
-			// Swup 页面切换后也需要检查
-			document.addEventListener("swup:page:view", adjustPageScale);
-			window.addEventListener("orientationchange", adjustPageScale);
+			const targetWidth = pageScaling.targetWidth || 2000;
+			const currentWidth = root.clientWidth;
+			const scale = Math.min(
+				1,
+				Math.max(0.85, currentWidth / targetWidth),
+			);
+			root.style.fontSize = `${scale * 100}%`;
 		}
+
+		adjustPageScale();
+		window.addEventListener("resize", adjustPageScale);
+		document.addEventListener("swup:page:view", adjustPageScale);
+		window.addEventListener("orientationchange", adjustPageScale);
 	})();
 </script>
 

--- a/src/layouts/partials/HeadTags.astro
+++ b/src/layouts/partials/HeadTags.astro
@@ -111,6 +111,10 @@ const favicons: Favicon[] =
 		configHue,
 		themeColorFixed: siteConfig.themeColor.fixed ?? false,
 		pageScaling: siteConfig.pageScaling,
+		ultrawidePostLayout: {
+			enable: siteConfig.ultrawidePostLayout?.enable ?? false,
+			allowSwitch: siteConfig.ultrawidePostLayout?.allowSwitch ?? true,
+		},
 	}}
 >
 	// Load the theme from local storage
@@ -146,6 +150,16 @@ const favicons: Favicon[] =
 		"--banner-height-extend",
 		`${offset}px`,
 	);
+
+	// 超宽屏文章布局。在首帧前落到 <html> 上，避免布局闪烁。
+	(function () {
+		const stored = ultrawidePostLayout.allowSwitch
+			? localStorage.getItem("ultrawidePostLayout")
+			: null;
+		document.documentElement.dataset.ultrawidePost = String(
+			stored !== null ? stored === "true" : ultrawidePostLayout.enable,
+		);
+	})();
 
 	// 兼容旧配置的可选页面缩放。默认布局不再依赖根字号缩放。
 	(function () {

--- a/src/pages/anime.astro
+++ b/src/pages/anime.astro
@@ -177,7 +177,8 @@ const emptyMessage = i18n(I18nKey.animeEmpty);
 					}
 					const mainGrid = document.getElementById("main-grid");
 					if (mainGrid) {
-						mainGrid.style.gridTemplateColumns = "17.5rem 1fr";
+						mainGrid.style.gridTemplateColumns =
+							"var(--layout-sidebar-width) minmax(0, 1fr)";
 						mainGrid.classList.add("two-column-layout");
 					}
 				} else {

--- a/src/plugins/remark-mark-sectionized.mjs
+++ b/src/plugins/remark-mark-sectionized.mjs
@@ -1,0 +1,33 @@
+import { visit } from "unist-util-visit";
+
+const SECTION_CLASS = "markdown-section";
+
+function normalizeClassNames(className) {
+	if (Array.isArray(className)) return className;
+	if (typeof className === "string")
+		return className.split(/\s+/).filter(Boolean);
+	return [];
+}
+
+/**
+ * Marks only the structural sections emitted by remark-sectionize.
+ *
+ * A dedicated class lets layout styles distinguish document sections from
+ * semantic <section> elements authored inside Markdown content.
+ */
+export function remarkMarkSectionized() {
+	return (tree) => {
+		visit(tree, "section", (node) => {
+			if (node.data?.hName !== "section") return;
+
+			const hProperties = node.data.hProperties ?? {};
+			const className = normalizeClassNames(hProperties.className);
+			if (!className.includes(SECTION_CLASS)) className.push(SECTION_CLASS);
+
+			node.data.hProperties = {
+				...hProperties,
+				className,
+			};
+		});
+	};
+}

--- a/src/scripts/anime-layout-handler.ts
+++ b/src/scripts/anime-layout-handler.ts
@@ -59,7 +59,8 @@ export function initAnimeLayoutHandler(options: LayoutHandlerOptions) {
 				"main-grid",
 			) as HTMLElement | null;
 			if (mainGrid) {
-				mainGrid.style.gridTemplateColumns = "17.5rem 1fr";
+				mainGrid.style.gridTemplateColumns =
+					"var(--layout-sidebar-width) minmax(0, 1fr)";
 				mainGrid.classList.add("two-column-layout");
 			}
 		} else {

--- a/src/scripts/right-sidebar-layout.js
+++ b/src/scripts/right-sidebar-layout.js
@@ -25,59 +25,40 @@ function getPostListLayout() {
 	return isLayoutSwitchEnabled() ? (localStorage.getItem("postListLayout") || "list") : "list";
 }
 
-function initPageLayout(pageType) {
-	// 获取布局配置
-	const defaultPostListLayout = getPostListLayout();
-
-	// 如果默认布局是网格模式，则隐藏右侧边栏
-	if (defaultPostListLayout === "grid") {
+function applyCurrentPageLayout() {
+	if (getPostListLayout() === "grid") {
 		hideRightSidebar();
 	} else {
 		showRightSidebar();
 	}
+}
+
+function initPageLayout(pageType) {
+	applyCurrentPageLayout();
 
 	// 监听布局切换事件
-	window.addEventListener("layoutChange", (event) => {
-		const layout = event.detail.layout;
-		if (layout === "grid") {
-			hideRightSidebar();
-		} else {
-			showRightSidebar();
-		}
+	window.addEventListener("layoutChange", () => {
+		applyCurrentPageLayout();
 	});
 
 	// 监听本地存储变化（用于跨标签页同步）
 	window.addEventListener("storage", (event) => {
 		if (event.key === "postListLayout") {
-			if (event.newValue === "grid") {
-				hideRightSidebar();
-			} else {
-				showRightSidebar();
-			}
+			applyCurrentPageLayout();
 		}
 	});
 
 	// 监听页面导航事件
 	document.addEventListener("astro:page-load", () => {
 		setTimeout(() => {
-			const currentLayout = getPostListLayout();
-			if (currentLayout === "grid") {
-				hideRightSidebar();
-			} else {
-				showRightSidebar();
-			}
+			applyCurrentPageLayout();
 		}, 100);
 	});
 
 	// 监听SWUP导航事件
 	document.addEventListener("swup:contentReplaced", () => {
 		setTimeout(() => {
-			const currentLayout = getPostListLayout();
-			if (currentLayout === "grid") {
-				hideRightSidebar();
-			} else {
-				showRightSidebar();
-			}
+			applyCurrentPageLayout();
 		}, 100);
 	});
 }

--- a/src/scripts/right-sidebar-layout.js
+++ b/src/scripts/right-sidebar-layout.js
@@ -97,7 +97,8 @@ function hideRightSidebar() {
 		// 调整主网格布局
 		const mainGrid = document.getElementById("main-grid");
 		if (mainGrid) {
-			mainGrid.style.gridTemplateColumns = "17.5rem 1fr";
+			mainGrid.style.gridTemplateColumns =
+				"var(--layout-sidebar-width) minmax(0, 1fr)";
 			mainGrid.setAttribute("data-layout-mode", "grid");
 		}
 	}

--- a/src/scripts/right-sidebar-layout.js
+++ b/src/scripts/right-sidebar-layout.js
@@ -9,7 +9,19 @@ function isLayoutSwitchEnabled() {
 	return document.documentElement.getAttribute("data-post-list-layout-enabled") !== "false";
 }
 
+function isPostPage() {
+	return (
+		document.getElementById("post-container") !== null ||
+		document.documentElement.dataset.layoutVariant === "post"
+	);
+}
+
 function getPostListLayout() {
+	// 文章页使用独立网格，不能继承首页文章列表的卡片模式。
+	if (isPostPage()) {
+		return "list";
+	}
+
 	return isLayoutSwitchEnabled() ? (localStorage.getItem("postListLayout") || "list") : "list";
 }
 

--- a/src/scripts/right-sidebar-layout.js
+++ b/src/scripts/right-sidebar-layout.js
@@ -9,19 +9,7 @@ function isLayoutSwitchEnabled() {
 	return document.documentElement.getAttribute("data-post-list-layout-enabled") !== "false";
 }
 
-function isPostPage() {
-	return (
-		document.getElementById("post-container") !== null ||
-		document.documentElement.dataset.layoutVariant === "post"
-	);
-}
-
 function getPostListLayout() {
-	// 文章页使用独立网格，不能继承首页文章列表的卡片模式。
-	if (isPostPage()) {
-		return "list";
-	}
-
 	return isLayoutSwitchEnabled() ? (localStorage.getItem("postListLayout") || "list") : "list";
 }
 

--- a/src/styles/banner.css
+++ b/src/styles/banner.css
@@ -628,7 +628,7 @@ html.is-page-transitioning #header-waves {
    ========================================================================== */
 @media (width >= 1280px) {
   #main-grid[data-layout-mode="grid"] {
-    grid-template-columns: 17.5rem 1fr !important;
+    grid-template-columns: var(--layout-sidebar-width) 1fr !important;
   }
 
   #main-grid[data-layout-mode="grid"] #swup-container {
@@ -639,7 +639,7 @@ html.is-page-transitioning #header-waves {
 /* 确保大屏桌面设备 Grid 模式配置 */
 @media (width >= 1280px) {
   #main-grid[data-layout-mode="grid"] {
-    grid-template-columns: 17.5rem 1fr !important;
+    grid-template-columns: var(--layout-sidebar-width) 1fr !important;
   }
 
   #main-grid[data-layout-mode="grid"] #swup-container {

--- a/src/styles/banner.css
+++ b/src/styles/banner.css
@@ -628,7 +628,7 @@ html.is-page-transitioning #header-waves {
    ========================================================================== */
 @media (width >= 1280px) {
   #main-grid[data-layout-mode="grid"] {
-    grid-template-columns: var(--layout-sidebar-width) 1fr !important;
+    grid-template-columns: var(--layout-sidebar-width) minmax(0, 1fr) !important;
   }
 
   #main-grid[data-layout-mode="grid"] #swup-container {
@@ -639,7 +639,7 @@ html.is-page-transitioning #header-waves {
 /* 确保大屏桌面设备 Grid 模式配置 */
 @media (width >= 1280px) {
   #main-grid[data-layout-mode="grid"] {
-    grid-template-columns: var(--layout-sidebar-width) 1fr !important;
+    grid-template-columns: var(--layout-sidebar-width) minmax(0, 1fr) !important;
   }
 
   #main-grid[data-layout-mode="grid"] #swup-container {

--- a/src/styles/layout-responsive.css
+++ b/src/styles/layout-responsive.css
@@ -9,6 +9,13 @@
   --layout-sidebar-width: 17.5rem;
 }
 
+/* A post keeps CardTOC as its sole persistent directory. FloatingTOC remains
+ * available on demand, while the external desktop directory stays available
+ * to other page variants. */
+html[data-layout-variant="post"] #toc-wrapper {
+  display: none;
+}
+
 @media (width >= 1920px) {
   html[data-layout-variant="post"] {
     --layout-page-width: 104rem;

--- a/src/styles/layout-responsive.css
+++ b/src/styles/layout-responsive.css
@@ -1,0 +1,23 @@
+/**
+ * Shared layout rails.
+ *
+ * The home and other index pages retain the original 90rem composition. Post
+ * pages opt into additional room only when the CSS viewport is genuinely wide.
+ */
+:root {
+  --layout-page-width: var(--page-width);
+  --layout-sidebar-width: 17.5rem;
+}
+
+@media (width >= 1920px) {
+  html[data-layout-variant="post"] {
+    --layout-page-width: 104rem;
+    --layout-sidebar-width: clamp(17.5rem, 14vw, 19rem);
+  }
+}
+
+@media (width >= 2560px) {
+  html[data-layout-variant="post"] {
+    --layout-page-width: 112rem;
+  }
+}

--- a/src/styles/layout-responsive.css
+++ b/src/styles/layout-responsive.css
@@ -17,15 +17,21 @@ html[data-layout-variant="post"] #toc-wrapper {
   display: none;
 }
 
+/* The reading rail grows with the post card instead of staying at 48rem, so a
+ * wide viewport no longer leaves prose stranded next to full-width code and
+ * tables. Every step starts at the previous step's value, keeping the rail
+ * continuous across both breakpoints. */
 @media (width >= 1920px) {
   html[data-layout-variant="post"] {
     --layout-page-width: clamp(104rem, 82vw, 132rem);
     --layout-sidebar-width: clamp(17.5rem, 14vw, 19rem);
+    --post-reading-width: clamp(48rem, 40vw, 64rem);
   }
 }
 
 @media (width >= 3200px) {
   html[data-layout-variant="post"] {
     --layout-page-width: clamp(132rem, 64vw, 152rem);
+    --post-reading-width: clamp(64rem, 20vw + 24rem, 72rem);
   }
 }

--- a/src/styles/layout-responsive.css
+++ b/src/styles/layout-responsive.css
@@ -7,6 +7,8 @@
 :root {
   --layout-page-width: var(--page-width);
   --layout-sidebar-width: 17.5rem;
+  --post-reading-width: 48rem;
+  --post-wide-content-width: 72rem;
 }
 
 /* A post keeps CardTOC as its sole persistent directory. FloatingTOC remains

--- a/src/styles/layout-responsive.css
+++ b/src/styles/layout-responsive.css
@@ -20,9 +20,12 @@ html[data-layout-variant="post"] #toc-wrapper {
 /* The reading rail grows with the post card instead of staying at 48rem, so a
  * wide viewport no longer leaves prose stranded next to full-width code and
  * tables. Every step starts at the previous step's value, keeping the rail
- * continuous across both breakpoints. */
+ * continuous across both breakpoints.
+ *
+ * Visitors can opt out through the settings panel, which flips
+ * data-ultrawide-post and restores the shared 90rem composition. */
 @media (width >= 1920px) {
-  html[data-layout-variant="post"] {
+  html[data-ultrawide-post="true"][data-layout-variant="post"] {
     --layout-page-width: clamp(104rem, 82vw, 132rem);
     --layout-sidebar-width: clamp(17.5rem, 14vw, 19rem);
     --post-reading-width: clamp(48rem, 40vw, 64rem);
@@ -30,7 +33,7 @@ html[data-layout-variant="post"] #toc-wrapper {
 }
 
 @media (width >= 3200px) {
-  html[data-layout-variant="post"] {
+  html[data-ultrawide-post="true"][data-layout-variant="post"] {
     --layout-page-width: clamp(132rem, 64vw, 152rem);
     --post-reading-width: clamp(64rem, 20vw + 24rem, 72rem);
   }

--- a/src/styles/layout-responsive.css
+++ b/src/styles/layout-responsive.css
@@ -8,7 +8,6 @@
   --layout-page-width: var(--page-width);
   --layout-sidebar-width: 17.5rem;
   --post-reading-width: 48rem;
-  --post-wide-content-width: 72rem;
 }
 
 /* A post keeps CardTOC as its sole persistent directory. FloatingTOC remains

--- a/src/styles/layout-responsive.css
+++ b/src/styles/layout-responsive.css
@@ -20,13 +20,13 @@ html[data-layout-variant="post"] #toc-wrapper {
 
 @media (width >= 1920px) {
   html[data-layout-variant="post"] {
-    --layout-page-width: 104rem;
+    --layout-page-width: clamp(104rem, 82vw, 132rem);
     --layout-sidebar-width: clamp(17.5rem, 14vw, 19rem);
   }
 }
 
-@media (width >= 2560px) {
+@media (width >= 3200px) {
   html[data-layout-variant="post"] {
-    --layout-page-width: 112rem;
+    --layout-page-width: clamp(132rem, 64vw, 152rem);
   }
 }

--- a/src/styles/post-content-rails.css
+++ b/src/styles/post-content-rails.css
@@ -2,46 +2,67 @@
  * Post reading and wide-content rails.
  *
  * Prose remains comfortable to read while intrinsically wide Markdown blocks
- * can use the rest of the post card without causing body-level overflow.
+ * extend from the reading edge to the post card's right content edge.
  */
-html[data-layout-variant="post"] #post-container {
-  container-type: inline-size;
-}
-
 html[data-layout-variant="post"] #post-container .markdown-content {
+  --post-reading-gutter: max(
+    0rem,
+    calc((100% - var(--post-reading-width)) / 2)
+  );
+
   width: 100%;
-  max-width: var(--post-reading-width) !important;
-  margin-inline: auto;
+  max-width: none !important;
+  margin-inline: 0;
 }
 
-@supports (width: 100cqi) {
-  html[data-layout-variant="post"] #post-container .markdown-content {
-    --post-reading-rail: min(var(--post-reading-width), 100cqi);
-    --post-wide-available-from-reading-start: calc(
-      (100cqi + var(--post-reading-rail)) / 2
-    );
-  }
+html[data-layout-variant="post"] #post-container .markdown-content > *,
+html[data-layout-variant="post"]
+  #post-container
+  .markdown-content
+  section
+  > * {
+  max-width: min(100%, var(--post-reading-width));
+  margin-inline-start: auto;
+  margin-inline-end: auto;
+}
 
-  html[data-layout-variant="post"]
-    #post-container
-    .markdown-content
-    :is(
-      .table-wrapper,
-      .expressive-code:not(.rehype-code-group .expressive-code),
-      .rehype-code-group,
-      .katex-display,
-      .mermaid-diagram-container,
-      .image-grid
-    ) {
-    --post-wide-rail: min(
-      var(--post-wide-content-width),
-      var(--post-wide-available-from-reading-start)
-    );
+html[data-layout-variant="post"]
+  #post-container
+  .markdown-content
+  section {
+  width: 100%;
+  max-width: none;
+  margin-inline: 0;
+}
 
-    box-sizing: border-box;
-    width: var(--post-wide-rail);
-    max-width: none;
-    margin-inline-start: 0;
-    margin-inline-end: calc(100% - var(--post-wide-rail));
-  }
+html[data-layout-variant="post"]
+  #post-container
+  .markdown-content
+  > :is(
+    .table-wrapper,
+    .expressive-code,
+    .rehype-code-group,
+    .katex-display,
+    .mermaid-diagram-container,
+    .image-grid,
+    p:has(> .katex-display)
+  ),
+html[data-layout-variant="post"]
+  #post-container
+  .markdown-content
+  section
+  > :is(
+    .table-wrapper,
+    .expressive-code,
+    .rehype-code-group,
+    .katex-display,
+    .mermaid-diagram-container,
+    .image-grid,
+    p:has(> .katex-display)
+  ) {
+  box-sizing: border-box;
+  width: calc(100% - var(--post-reading-gutter));
+  max-width: none;
+  margin-inline-start: var(--post-reading-gutter);
+  margin-inline-end: 0;
 }

--- a/src/styles/post-content-rails.css
+++ b/src/styles/post-content-rails.css
@@ -1,0 +1,36 @@
+/**
+ * Post reading and wide-content rails.
+ *
+ * Prose remains comfortable to read while intrinsically wide Markdown blocks
+ * can use the rest of the post card without causing body-level overflow.
+ */
+html[data-layout-variant="post"] #post-container {
+  container-type: inline-size;
+}
+
+html[data-layout-variant="post"] #post-container .markdown-content {
+  width: 100%;
+  max-width: var(--post-reading-width) !important;
+  margin-inline: auto;
+}
+
+@supports (width: 100cqi) {
+  html[data-layout-variant="post"]
+    #post-container
+    .markdown-content
+    :is(
+      .table-wrapper,
+      .expressive-code:not(.rehype-code-group .expressive-code),
+      .rehype-code-group,
+      .katex-display,
+      .mermaid-diagram-container,
+      .image-grid
+    ) {
+    --post-wide-rail: min(var(--post-wide-content-width), 100cqi);
+
+    box-sizing: border-box;
+    width: var(--post-wide-rail);
+    max-width: none;
+    margin-inline: calc((100% - var(--post-wide-rail)) / 2);
+  }
+}

--- a/src/styles/post-content-rails.css
+++ b/src/styles/post-content-rails.css
@@ -15,6 +15,13 @@ html[data-layout-variant="post"] #post-container .markdown-content {
 }
 
 @supports (width: 100cqi) {
+  html[data-layout-variant="post"] #post-container .markdown-content {
+    --post-reading-rail: min(var(--post-reading-width), 100cqi);
+    --post-wide-available-from-reading-start: calc(
+      (100cqi + var(--post-reading-rail)) / 2
+    );
+  }
+
   html[data-layout-variant="post"]
     #post-container
     .markdown-content
@@ -26,11 +33,15 @@ html[data-layout-variant="post"] #post-container .markdown-content {
       .mermaid-diagram-container,
       .image-grid
     ) {
-    --post-wide-rail: min(var(--post-wide-content-width), 100cqi);
+    --post-wide-rail: min(
+      var(--post-wide-content-width),
+      var(--post-wide-available-from-reading-start)
+    );
 
     box-sizing: border-box;
     width: var(--post-wide-rail);
     max-width: none;
-    margin-inline: calc((100% - var(--post-wide-rail)) / 2);
+    margin-inline-start: 0;
+    margin-inline-end: calc(100% - var(--post-wide-rail));
   }
 }

--- a/src/styles/post-content-rails.css
+++ b/src/styles/post-content-rails.css
@@ -1,35 +1,28 @@
 /**
  * Post reading and wide-content rails.
  *
- * Prose remains comfortable to read while intrinsically wide Markdown blocks
- * extend from the reading edge to the post card's right content edge.
+ * Prose and wide blocks share the post card's left content edge. Only direct
+ * children of the document root or generated Markdown sections opt into these
+ * rails, so nested lists, blockquotes, and components keep their indentation.
  */
 html[data-layout-variant="post"] #post-container .markdown-content {
-  --post-reading-gutter: max(
-    0rem,
-    calc((100% - var(--post-reading-width)) / 2)
-  );
-
   width: 100%;
   max-width: none !important;
   margin-inline: 0;
 }
 
-html[data-layout-variant="post"] #post-container .markdown-content > *,
 html[data-layout-variant="post"]
   #post-container
-  .markdown-content
-  section
+  :where(.markdown-content, .markdown-section)
   > * {
   max-width: min(100%, var(--post-reading-width));
-  margin-inline-start: auto;
+  margin-inline-start: 0;
   margin-inline-end: auto;
 }
 
 html[data-layout-variant="post"]
   #post-container
-  .markdown-content
-  section {
+  .markdown-section {
   width: 100%;
   max-width: none;
   margin-inline: 0;
@@ -37,20 +30,7 @@ html[data-layout-variant="post"]
 
 html[data-layout-variant="post"]
   #post-container
-  .markdown-content
-  > :is(
-    .table-wrapper,
-    .expressive-code,
-    .rehype-code-group,
-    .katex-display,
-    .mermaid-diagram-container,
-    .image-grid,
-    p:has(> .katex-display)
-  ),
-html[data-layout-variant="post"]
-  #post-container
-  .markdown-content
-  section
+  :where(.markdown-content, .markdown-section)
   > :is(
     .table-wrapper,
     .expressive-code,
@@ -61,8 +41,8 @@ html[data-layout-variant="post"]
     p:has(> .katex-display)
   ) {
   box-sizing: border-box;
-  width: calc(100% - var(--post-reading-gutter));
+  width: 100%;
   max-width: none;
-  margin-inline-start: var(--post-reading-gutter);
+  margin-inline-start: 0;
   margin-inline-end: 0;
 }

--- a/src/styles/variables.styl
+++ b/src/styles/variables.styl
@@ -98,7 +98,7 @@ define({
   --toc-badge-bg: oklch(0.9 0.045 var(--hue)) var(--btn-regular-bg)
   --toc-btn-hover: oklch(0.92 0.015 var(--hue)) oklch(0.22 0.02 var(--hue))
   --toc-btn-active: oklch(0.90 0.015 var(--hue)) oklch(0.25 0.02 var(--hue))
-  --toc-width: calc((100vw - var(--page-width)) / 2 - 1rem)
+  --toc-width: clamp(0rem, calc((100vw - var(--layout-page-width)) / 2 - 1rem), 22rem)
   --toc-item-active: oklch(0.70 0.13 var(--hue)) oklch(0.35 0.07 var(--hue))
 })
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -55,6 +55,12 @@ export interface SiteConfig {
 		};
 	};
 
+	// 文章页超宽屏布局配置
+	ultrawidePostLayout?: {
+		enable: boolean; // 访客未手动切换时的初始状态
+		allowSwitch?: boolean; // 是否在设置面板中显示开关
+	};
+
 	// 顶栏标题配置
 	navbarTitle?: {
 		mode?: "text-icon" | "logo"; // 显示模式："text-icon" 显示图标+文本，"logo" 仅显示Logo

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -63,9 +63,9 @@ export interface SiteConfig {
 		logo?: string; // 网站Logo图片路径
 	};
 
-	// 页面自动缩放配置
+	// 旧版页面自动缩放配置
 	pageScaling?: {
-		enable: boolean; // 是否开启自动缩放
+		enable: boolean; // 默认关闭；启用时保留旧版根字号缩放行为
 		targetWidth?: number; // 目标宽度，低于此宽度时开始缩放
 	};
 

--- a/src/utils/grid-layout-utils.ts
+++ b/src/utils/grid-layout-utils.ts
@@ -121,16 +121,18 @@ export function calculateGridLayout(
 	let desktopGridCols = "lg:grid-cols-1";
 	if (desktopShowLeftSidebar && desktopShowRightSidebar) {
 		desktopGridCols =
-			"lg:grid-cols-[var(--layout-sidebar-width)_1fr_var(--layout-sidebar-width)]";
+			"lg:grid-cols-[var(--layout-sidebar-width)_minmax(0,1fr)_var(--layout-sidebar-width)]";
 	} else if (desktopShowLeftSidebar) {
-		desktopGridCols = "lg:grid-cols-[var(--layout-sidebar-width)_1fr]";
+		desktopGridCols =
+			"lg:grid-cols-[var(--layout-sidebar-width)_minmax(0,1fr)]";
 	} else if (desktopShowRightSidebar) {
-		desktopGridCols = "lg:grid-cols-[1fr_var(--layout-sidebar-width)]";
+		desktopGridCols =
+			"lg:grid-cols-[minmax(0,1fr)_var(--layout-sidebar-width)]";
 	}
 
 	const gridCols = `
 		${mobileShowSidebar ? "grid-cols-1" : "grid-cols-1"}
-		${tabletAnySidebar ? "md:grid-cols-[var(--layout-sidebar-width)_1fr]" : "md:grid-cols-1"}
+		${tabletAnySidebar ? "md:grid-cols-[var(--layout-sidebar-width)_minmax(0,1fr)]" : "md:grid-cols-1"}
 		${desktopGridCols}
 	`
 		.trim()
@@ -168,7 +170,7 @@ export function calculateGridLayout(
 	}
 
 	const mainContentClass = `
-		transition-swup-fade overflow-hidden w-full
+		transition-swup-fade overflow-hidden min-w-0 w-full
 		col-span-1 row-start-1 row-end-2
 		${tabletAnySidebar ? "md:col-start-2 md:col-end-3" : "md:col-start-1 md:col-end-2"}
 		${desktopShowSidebar ? desktopMainPos : "lg:col-span-1"}

--- a/src/utils/grid-layout-utils.ts
+++ b/src/utils/grid-layout-utils.ts
@@ -120,16 +120,17 @@ export function calculateGridLayout(
 	// 动态网格布局类名 - 根据侧边栏模式和是否有组件调整列宽
 	let desktopGridCols = "lg:grid-cols-1";
 	if (desktopShowLeftSidebar && desktopShowRightSidebar) {
-		desktopGridCols = "lg:grid-cols-[17.5rem_1fr_17.5rem]";
+		desktopGridCols =
+			"lg:grid-cols-[var(--layout-sidebar-width)_1fr_var(--layout-sidebar-width)]";
 	} else if (desktopShowLeftSidebar) {
-		desktopGridCols = "lg:grid-cols-[17.5rem_1fr]";
+		desktopGridCols = "lg:grid-cols-[var(--layout-sidebar-width)_1fr]";
 	} else if (desktopShowRightSidebar) {
-		desktopGridCols = "lg:grid-cols-[1fr_17.5rem]";
+		desktopGridCols = "lg:grid-cols-[1fr_var(--layout-sidebar-width)]";
 	}
 
 	const gridCols = `
 		${mobileShowSidebar ? "grid-cols-1" : "grid-cols-1"}
-		${tabletAnySidebar ? "md:grid-cols-[17.5rem_1fr]" : "md:grid-cols-1"}
+		${tabletAnySidebar ? "md:grid-cols-[var(--layout-sidebar-width)_1fr]" : "md:grid-cols-1"}
 		${desktopGridCols}
 	`
 		.trim()
@@ -139,8 +140,8 @@ export function calculateGridLayout(
 	const sidebarClass = `
 		onload-animation
 		${mobileShowSidebar && hasMobileDrawerComponents ? "block" : "hidden"}
-		${tabletShowLeftSidebar ? "md:block md:mb-4 md:max-w-[17.5rem]" : "md:hidden"}
-		${desktopShowLeftSidebar ? "lg:block lg:mb-4 lg:row-start-1 lg:row-end-2 lg:max-w-[17.5rem] lg:col-start-1 lg:col-end-2" : "lg:hidden"}
+		${tabletShowLeftSidebar ? "md:block md:mb-4 md:max-w-(--layout-sidebar-width)" : "md:hidden"}
+		${desktopShowLeftSidebar ? "lg:block lg:mb-4 lg:row-start-1 lg:row-end-2 lg:max-w-(--layout-sidebar-width) lg:col-start-1 lg:col-end-2" : "lg:hidden"}
 	`
 		.trim()
 		.replace(/\s+/g, " ");
@@ -149,8 +150,8 @@ export function calculateGridLayout(
 	const rightSidebarClass = `
 		onload-animation
 		hidden
-		${tabletShowRightSidebar ? "md:block md:mb-4 md:max-w-[17.5rem]" : "md:hidden"}
-		${desktopShowRightSidebar ? `lg:block lg:self-start lg:h-fit lg:mb-4 lg:max-w-[17.5rem] ${desktopShowLeftSidebar ? "lg:col-start-3 lg:col-end-4" : "lg:col-start-2 lg:col-end-3"} lg:col-span-1` : "lg:hidden"}
+		${tabletShowRightSidebar ? "md:block md:mb-4 md:max-w-(--layout-sidebar-width)" : "md:hidden"}
+		${desktopShowRightSidebar ? `lg:block lg:self-start lg:h-fit lg:mb-4 lg:max-w-(--layout-sidebar-width) ${desktopShowLeftSidebar ? "lg:col-start-3 lg:col-end-4" : "lg:col-start-2 lg:col-end-3"} lg:col-span-1` : "lg:hidden"}
 		${initialRightSidebarHidden ? "hidden-in-grid-mode" : ""}
 	`
 		.trim()

--- a/src/utils/setting-utils.ts
+++ b/src/utils/setting-utils.ts
@@ -415,3 +415,22 @@ export function setSakuraEnabled(enabled: boolean): void {
 		new CustomEvent("sakura-toggle", { detail: { enabled } }),
 	);
 }
+
+// ─── Ultrawide post layout ───────────────────────────────────
+
+export function getDefaultUltrawidePostLayout(): boolean {
+	return siteConfig.ultrawidePostLayout?.enable ?? false;
+}
+
+export function getStoredUltrawidePostLayout(): boolean {
+	if (!(siteConfig.ultrawidePostLayout?.allowSwitch ?? true)) {
+		return getDefaultUltrawidePostLayout();
+	}
+	const stored = localStorage.getItem("ultrawidePostLayout");
+	return stored !== null ? stored === "true" : getDefaultUltrawidePostLayout();
+}
+
+export function setUltrawidePostLayout(enabled: boolean): void {
+	localStorage.setItem("ultrawidePostLayout", String(enabled));
+	document.documentElement.dataset.ultrawidePost = String(enabled);
+}

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -58,6 +58,10 @@ const markdownExtendStyles = await readFile(
 	new URL("../src/styles/markdown-extend.styl", import.meta.url),
 	"utf8",
 );
+const postContentRailStyles = await readFile(
+	new URL("../src/styles/post-content-rails.css", import.meta.url),
+	"utf8",
+);
 const encryptorSource = await readFile(
 	new URL("../src/components/features/auth/Encryptor.astro", import.meta.url),
 	"utf8",
@@ -143,6 +147,38 @@ describe("Markdown layout regressions", () => {
 			markdownExtendStyles,
 			/\.bdm-title\s+[\s\S]*?margin-bottom:\s*-/,
 			"negative title margins pull marginless content such as tables into the title",
+		);
+	});
+
+	it("separates the post reading rail from intrinsically wide content", () => {
+		assert.ok(
+			markdownSource.includes('import "@/styles/post-content-rails.css";'),
+			"post rail styles must follow every Markdown rendering path",
+		);
+		assert.match(responsiveLayoutStyles, /--post-reading-width:\s*48rem/);
+		assert.match(responsiveLayoutStyles, /--post-wide-content-width:\s*72rem/);
+		assert.match(
+			postContentRailStyles,
+			/\.markdown-content\s*\{[\s\S]*?max-width:\s*var\(--post-reading-width\)\s*!important/,
+		);
+
+		for (const wideContentClass of [
+			"table-wrapper",
+			"expressive-code",
+			"rehype-code-group",
+			"katex-display",
+			"mermaid-diagram-container",
+			"image-grid",
+		]) {
+			assert.ok(
+				postContentRailStyles.includes(`.${wideContentClass}`),
+				`${wideContentClass} must opt into the wide-content rail`,
+			);
+		}
+
+		assert.match(
+			postContentRailStyles,
+			/--post-wide-rail:\s*min\(var\(--post-wide-content-width\), 100cqi\)/,
 		);
 	});
 });

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { describe, it } from "node:test";
+import { remarkMarkSectionized } from "../src/plugins/remark-mark-sectionized.mjs";
 
 const layoutSource = await readFile(
 	new URL("../src/layouts/Layout.astro", import.meta.url),
@@ -163,12 +164,13 @@ describe("Markdown layout regressions", () => {
 		);
 		assert.match(
 			postContentRailStyles,
-			/--post-reading-gutter:\s*max\([\s\S]*?calc\(\(100% - var\(--post-reading-width\)\) \/ 2\)[\s\S]*?\)/,
+			/:where\(\.markdown-content, \.markdown-section\)[\s\S]*?>\s*\*\s*\{[\s\S]*?max-width:\s*min\(100%, var\(--post-reading-width\)\)[\s\S]*?margin-inline-start:\s*0;[\s\S]*?margin-inline-end:\s*auto/,
+			"ordinary Markdown blocks must stay on a left-aligned reading rail",
 		);
 		assert.match(
 			postContentRailStyles,
-			/\.markdown-content\s*>\s*\*,[\s\S]*?section[\s\S]*?>\s*\*\s*\{[\s\S]*?max-width:\s*min\(100%, var\(--post-reading-width\)\)/,
-			"ordinary Markdown blocks must remain on the bounded reading rail",
+			/\.markdown-section\s*\{[\s\S]*?width:\s*100%;[\s\S]*?max-width:\s*none;[\s\S]*?margin-inline:\s*0/,
+			"generated section wrappers must not add another reading-rail indent",
 		);
 
 		for (const wideContentClass of [
@@ -187,14 +189,38 @@ describe("Markdown layout regressions", () => {
 
 		assert.match(
 			postContentRailStyles,
-			/width:\s*calc\(100% - var\(--post-reading-gutter\)\);[\s\S]*?margin-inline-start:\s*var\(--post-reading-gutter\);[\s\S]*?margin-inline-end:\s*0/,
-			"wide blocks must finish at the post card's right content edge",
+			/:where\(\.markdown-content, \.markdown-section\)[\s\S]*?>\s*:is\([\s\S]*?\)\s*\{[\s\S]*?width:\s*100%;[\s\S]*?margin-inline-start:\s*0;[\s\S]*?margin-inline-end:\s*0/,
+			"only direct document-flow blocks may occupy the full wide rail",
 		);
 		assert.doesNotMatch(
 			postContentRailStyles,
-			/100cqi|--post-wide-content-width|--post-wide-rail/,
-			"wide rails must not depend on container-unit overflow from a narrow parent",
+			/\.markdown-content\s+section|section\s*>\s*:is/,
+			"raw or nested section elements must not opt into document rails",
 		);
+	});
+
+	it("marks only remark-sectionize document sections", () => {
+		const sectionized = {
+			type: "section",
+			data: {
+				hName: "section",
+				hProperties: { className: ["existing-section-class"] },
+			},
+			children: [],
+		};
+		const authoredHtml = {
+			type: "html",
+			value: "<section><pre>keep local indentation</pre></section>",
+		};
+		const tree = { type: "root", children: [sectionized, authoredHtml] };
+
+		remarkMarkSectionized()(tree);
+
+		assert.deepEqual(sectionized.data.hProperties.className, [
+			"existing-section-class",
+			"markdown-section",
+		]);
+		assert.equal(authoredHtml.data, undefined);
 	});
 });
 

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -6,6 +6,14 @@ const layoutSource = await readFile(
 	new URL("../src/layouts/Layout.astro", import.meta.url),
 	"utf8",
 );
+const headTagsSource = await readFile(
+	new URL("../src/layouts/partials/HeadTags.astro", import.meta.url),
+	"utf8",
+);
+const siteConfigSource = await readFile(
+	new URL("../src/config/siteConfig.ts", import.meta.url),
+	"utf8",
+);
 const bannerStyles = await readFile(
 	new URL("../src/styles/banner.css", import.meta.url),
 	"utf8",
@@ -171,5 +179,25 @@ describe("Fullscreen banner layout regressions", () => {
 				`${stickyId} must not use the unscoped banner offset compensation`,
 			);
 		}
+	});
+});
+
+describe("Page scaling regressions", () => {
+	it("keeps root-font scaling opt-in and continuous across desktop widths", () => {
+		assert.match(
+			siteConfigSource,
+			/pageScaling:\s*\{[\s\S]*?enable:\s*false/,
+			"responsive layout must not depend on root-font scaling by default",
+		);
+		assert.doesNotMatch(
+			headTagsSource,
+			/window\.innerWidth\s*<=\s*1280/,
+			"legacy scaling must not jump between 1280px and 1281px",
+		);
+		assert.match(
+			headTagsSource,
+			/Math\.max\(0\.85, currentWidth \/ targetWidth\)/,
+			"opt-in legacy scaling must use one continuous clamp",
+		);
 	});
 });

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -42,6 +42,14 @@ const gridLayoutUtilsSource = await readFile(
 	new URL("../src/utils/grid-layout-utils.ts", import.meta.url),
 	"utf8",
 );
+const cardTocSource = await readFile(
+	new URL("../src/components/widgets/card-toc/CardTOC.astro", import.meta.url),
+	"utf8",
+);
+const variablesSource = await readFile(
+	new URL("../src/styles/variables.styl", import.meta.url),
+	"utf8",
+);
 const markdownSource = await readFile(
 	new URL("../src/components/misc/Markdown.astro", import.meta.url),
 	"utf8",
@@ -263,6 +271,20 @@ describe("Page layout variant regressions", () => {
 		assert.match(
 			rightSidebarLayoutSource,
 			/if \(isPostPage\(\)\) \{\s*return "list"/,
+		);
+	});
+
+	it("keeps one persistent post TOC and shares the configured depth", () => {
+		assert.match(
+			responsiveLayoutStyles,
+			/html\[data-layout-variant="post"\] #toc-wrapper\s*\{\s*display:\s*none/,
+		);
+		assert.match(cardTocSource, /const tocDepth = siteConfig\.toc\.depth/);
+		assert.match(cardTocSource, /maxLevel,/);
+		assert.doesNotMatch(cardTocSource, /maxLevel:\s*3/);
+		assert.match(
+			variablesSource,
+			/--toc-width:\s*clamp\(0rem,[\s\S]*?var\(--layout-page-width\)[\s\S]*?22rem\)/,
 		);
 	});
 });

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -286,11 +286,11 @@ describe("Page layout variant regressions", () => {
 		);
 		assert.match(
 			responsiveLayoutStyles,
-			/@media \(width >= 1920px\)[\s\S]*?html\[data-layout-variant="post"\][\s\S]*?--layout-page-width:\s*104rem/,
+			/@media \(width >= 1920px\)[\s\S]*?html\[data-layout-variant="post"\][\s\S]*?--layout-page-width:\s*clamp\(104rem, 82vw, 132rem\)/,
 		);
 		assert.match(
 			responsiveLayoutStyles,
-			/@media \(width >= 2560px\)[\s\S]*?--layout-page-width:\s*112rem/,
+			/@media \(width >= 3200px\)[\s\S]*?--layout-page-width:\s*clamp\(132rem, 64vw, 152rem\)/,
 		);
 		assert.match(
 			responsiveLayoutStyles,
@@ -305,6 +305,11 @@ describe("Page layout variant regressions", () => {
 			gridLayoutUtilsSource,
 			/transition-swup-fade overflow-hidden min-w-0 w-full/,
 		);
+
+		const qhdPageWidth = Math.min(132 * 16, Math.max(104 * 16, 2560 * 0.82));
+		const uhdPageWidth = Math.min(152 * 16, Math.max(132 * 16, 3840 * 0.64));
+		assert.ok(qhdPageWidth / 2560 >= 0.8);
+		assert.ok(uhdPageWidth / 3840 >= 0.63);
 	});
 
 	it("keeps the global grid preference effective on article pages", () => {

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -297,6 +297,14 @@ describe("Page layout variant regressions", () => {
 			/--layout-sidebar-width:\s*clamp\(17\.5rem, 14vw, 19rem\)/,
 		);
 		assert.match(gridLayoutUtilsSource, /var\(--layout-sidebar-width\)/);
+		assert.match(
+			gridLayoutUtilsSource,
+			/grid-cols-\[var\(--layout-sidebar-width\)_minmax\(0,1fr\)_var\(--layout-sidebar-width\)\]/,
+		);
+		assert.match(
+			gridLayoutUtilsSource,
+			/transition-swup-fade overflow-hidden min-w-0 w-full/,
+		);
 	});
 
 	it("does not let the post-list grid preference override article pages", () => {

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -156,10 +156,19 @@ describe("Markdown layout regressions", () => {
 			"post rail styles must follow every Markdown rendering path",
 		);
 		assert.match(responsiveLayoutStyles, /--post-reading-width:\s*48rem/);
-		assert.match(responsiveLayoutStyles, /--post-wide-content-width:\s*72rem/);
 		assert.match(
 			postContentRailStyles,
-			/\.markdown-content\s*\{[\s\S]*?max-width:\s*var\(--post-reading-width\)\s*!important/,
+			/\.markdown-content\s*\{[\s\S]*?width:\s*100%;[\s\S]*?max-width:\s*none\s*!important/,
+			"the Markdown root must expose the whole post card to both rails",
+		);
+		assert.match(
+			postContentRailStyles,
+			/--post-reading-gutter:\s*max\([\s\S]*?calc\(\(100% - var\(--post-reading-width\)\) \/ 2\)[\s\S]*?\)/,
+		);
+		assert.match(
+			postContentRailStyles,
+			/\.markdown-content\s*>\s*\*,[\s\S]*?section[\s\S]*?>\s*\*\s*\{[\s\S]*?max-width:\s*min\(100%, var\(--post-reading-width\)\)/,
+			"ordinary Markdown blocks must remain on the bounded reading rail",
 		);
 
 		for (const wideContentClass of [
@@ -178,19 +187,13 @@ describe("Markdown layout regressions", () => {
 
 		assert.match(
 			postContentRailStyles,
-			/--post-wide-available-from-reading-start:\s*calc\([\s\S]*?100cqi \+ var\(--post-reading-rail\)[\s\S]*?\/ 2[\s\S]*?\)/,
-		);
-		assert.match(
-			postContentRailStyles,
-			/--post-wide-rail:\s*min\([\s\S]*?var\(--post-wide-content-width\),[\s\S]*?var\(--post-wide-available-from-reading-start\)[\s\S]*?\)/,
-		);
-		assert.match(
-			postContentRailStyles,
-			/margin-inline-start:\s*0;[\s\S]*?margin-inline-end:\s*calc\(100% - var\(--post-wide-rail\)\)/,
+			/width:\s*calc\(100% - var\(--post-reading-gutter\)\);[\s\S]*?margin-inline-start:\s*var\(--post-reading-gutter\);[\s\S]*?margin-inline-end:\s*0/,
+			"wide blocks must finish at the post card's right content edge",
 		);
 		assert.doesNotMatch(
 			postContentRailStyles,
-			/margin-inline:\s*calc\(\(100% - var\(--post-wide-rail\)\) \/ 2\)/,
+			/100cqi|--post-wide-content-width|--post-wide-rail/,
+			"wide rails must not depend on container-unit overflow from a narrow parent",
 		);
 	});
 });

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -308,6 +308,18 @@ describe("Page layout variant regressions", () => {
 			rightSidebarLayoutSource,
 			/if \(isPostPage\(\)\) \{\s*return "list"/,
 		);
+		assert.match(
+			rightSidebarLayoutSource,
+			/window\.addEventListener\("layoutChange", \(\) => \{\s*applyCurrentPageLayout\(\)/,
+		);
+		assert.match(
+			rightSidebarLayoutSource,
+			/event\.key === "postListLayout"\) \{\s*applyCurrentPageLayout\(\)/,
+		);
+		assert.doesNotMatch(
+			rightSidebarLayoutSource,
+			/const layout = event\.detail\.layout/,
+		);
 	});
 
 	it("keeps one persistent post TOC and shares the configured depth", () => {

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -78,6 +78,18 @@ const globalStyleCheckSource = await readFile(
 	new URL("../scripts/check-global-style-loading.mjs", import.meta.url),
 	"utf8",
 );
+const settingsPanelSource = await readFile(
+	new URL(
+		"../src/components/features/settings/SettingsPanel.svelte",
+		import.meta.url,
+	),
+	"utf8",
+);
+const translationSources = await Promise.all(
+	["en", "zh_CN", "zh_TW", "ja"].map((lang) =>
+		readFile(new URL(`../src/i18n/languages/${lang}.ts`, import.meta.url), "utf8"),
+	),
+);
 const packageConfig = JSON.parse(
 	await readFile(new URL("../package.json", import.meta.url), "utf8"),
 );
@@ -327,7 +339,7 @@ describe("Page layout variant regressions", () => {
 		);
 		assert.match(
 			responsiveLayoutStyles,
-			/@media \(width >= 1920px\)[\s\S]*?html\[data-layout-variant="post"\][\s\S]*?--layout-page-width:\s*clamp\(104rem, 82vw, 132rem\)/,
+			/@media \(width >= 1920px\)[\s\S]*?html\[data-ultrawide-post="true"\]\[data-layout-variant="post"\][\s\S]*?--layout-page-width:\s*clamp\(104rem, 82vw, 132rem\)/,
 		);
 		assert.match(
 			responsiveLayoutStyles,
@@ -380,6 +392,58 @@ describe("Page layout variant regressions", () => {
 				readingWidth(viewport) >= readingWidth(viewport - 320),
 				`the rail must not shrink as the viewport grows at ${viewport}px`,
 			);
+		}
+	});
+
+	it("keeps the wide-screen post layout switchable and pre-painted", () => {
+		assert.match(
+			siteConfigSource,
+			/ultrawidePostLayout:\s*\{[\s\S]*?enable:\s*true[\s\S]*?allowSwitch:\s*true/,
+			"the wide-screen layout ships enabled and visitor-switchable",
+		);
+		assert.match(
+			layoutSource,
+			/data-ultrawide-post=\{siteConfig\.ultrawidePostLayout\?\.enable \? "true" : "false"\}/,
+			"the configured default must render into the static HTML",
+		);
+		assert.match(
+			headTagsSource,
+			/localStorage\.getItem\("ultrawidePostLayout"\)/,
+			"the stored preference must be applied before the first paint",
+		);
+		assert.match(
+			headTagsSource,
+			/document\.documentElement\.dataset\.ultrawidePost = String\(/,
+		);
+
+		for (const gatedRule of [
+			/--layout-page-width:\s*clamp\(104rem/,
+			/--layout-page-width:\s*clamp\(132rem/,
+		]) {
+			const block = responsiveLayoutStyles
+				.split("@media")
+				.find((chunk) => gatedRule.test(chunk));
+			assert.ok(
+				block?.includes('html[data-ultrawide-post="true"]'),
+				"every wide-screen override must sit behind the opt-out attribute",
+			);
+		}
+
+		assert.match(
+			settingsPanelSource,
+			/getStoredUltrawidePostLayout\(\)/,
+			"the panel must restore the stored preference on mount",
+		);
+		assert.match(
+			settingsPanelSource,
+			/\{#if isUltrawidePostLayoutSwitchable\}[\s\S]*?i18n\(I18nKey\.settingsFeatures\)[\s\S]*?i18n\(I18nKey\.ultrawidePostLayout\)/,
+			"the toggle must live in its own Features group",
+		);
+
+		for (const translation of translationSources) {
+			assert.match(translation, /\[Key\.ultrawidePostLayout\]:/);
+			assert.match(translation, /\[Key\.ultrawidePostLayoutHint\]:/);
+			assert.match(translation, /\[Key\.settingsFeatures\]:/);
 		}
 	});
 

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -10,6 +10,18 @@ const headTagsSource = await readFile(
 	new URL("../src/layouts/partials/HeadTags.astro", import.meta.url),
 	"utf8",
 );
+const gridScriptsSource = await readFile(
+	new URL("../src/layouts/partials/GridScripts.astro", import.meta.url),
+	"utf8",
+);
+const mainGridLayoutSource = await readFile(
+	new URL("../src/layouts/MainGridLayout.astro", import.meta.url),
+	"utf8",
+);
+const rightSidebarLayoutSource = await readFile(
+	new URL("../src/scripts/right-sidebar-layout.js", import.meta.url),
+	"utf8",
+);
 const siteConfigSource = await readFile(
 	new URL("../src/config/siteConfig.ts", import.meta.url),
 	"utf8",
@@ -198,6 +210,31 @@ describe("Page scaling regressions", () => {
 			headTagsSource,
 			/Math\.max\(0\.85, currentWidth \/ targetWidth\)/,
 			"opt-in legacy scaling must use one continuous clamp",
+		);
+	});
+});
+
+describe("Page layout variant regressions", () => {
+	it("keeps the post layout variant synchronized across Swup navigation", () => {
+		assert.match(layoutSource, /data-layout-variant=\{layoutVariant\}/);
+		assert.match(
+			mainGridLayoutSource,
+			/const layoutVariant = postSlug \? "post" : isHomePage \? "home" : "default"/,
+		);
+		assert.match(
+			gridScriptsSource,
+			/document\.addEventListener\("swup:page:view", function \(\) \{\s*syncLayoutVariant\(\)/,
+		);
+	});
+
+	it("does not let the post-list grid preference override article pages", () => {
+		assert.match(
+			gridScriptsSource,
+			/document\.documentElement\.dataset\.layoutVariant === "post"/,
+		);
+		assert.match(
+			rightSidebarLayoutSource,
+			/if \(isPostPage\(\)\) \{\s*return "list"/,
 		);
 	});
 });

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -34,6 +34,14 @@ const mainStyles = await readFile(
 	new URL("../src/styles/main.css", import.meta.url),
 	"utf8",
 );
+const responsiveLayoutStyles = await readFile(
+	new URL("../src/styles/layout-responsive.css", import.meta.url),
+	"utf8",
+);
+const gridLayoutUtilsSource = await readFile(
+	new URL("../src/utils/grid-layout-utils.ts", import.meta.url),
+	"utf8",
+);
 const markdownSource = await readFile(
 	new URL("../src/components/misc/Markdown.astro", import.meta.url),
 	"utf8",
@@ -225,6 +233,26 @@ describe("Page layout variant regressions", () => {
 			gridScriptsSource,
 			/document\.addEventListener\("swup:page:view", function \(\) \{\s*syncLayoutVariant\(\)/,
 		);
+	});
+
+	it("expands only post pages with bounded wide-screen dimensions", () => {
+		assert.match(
+			responsiveLayoutStyles,
+			/:root\s*\{[\s\S]*?--layout-page-width:\s*var\(--page-width\)/,
+		);
+		assert.match(
+			responsiveLayoutStyles,
+			/@media \(width >= 1920px\)[\s\S]*?html\[data-layout-variant="post"\][\s\S]*?--layout-page-width:\s*104rem/,
+		);
+		assert.match(
+			responsiveLayoutStyles,
+			/@media \(width >= 2560px\)[\s\S]*?--layout-page-width:\s*112rem/,
+		);
+		assert.match(
+			responsiveLayoutStyles,
+			/--layout-sidebar-width:\s*clamp\(17\.5rem, 14vw, 19rem\)/,
+		);
+		assert.match(gridLayoutUtilsSource, /var\(--layout-sidebar-width\)/);
 	});
 
 	it("does not let the post-list grid preference override article pages", () => {

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -353,6 +353,36 @@ describe("Page layout variant regressions", () => {
 		assert.ok(uhdPageWidth / 3840 >= 0.63);
 	});
 
+	it("grows the post reading rail with the wide-screen post card", () => {
+		assert.match(
+			responsiveLayoutStyles,
+			/@media \(width >= 1920px\)[\s\S]*?--post-reading-width:\s*clamp\(48rem, 40vw, 64rem\)/,
+		);
+		assert.match(
+			responsiveLayoutStyles,
+			/@media \(width >= 3200px\)[\s\S]*?--post-reading-width:\s*clamp\(64rem, 20vw \+ 24rem, 72rem\)/,
+		);
+
+		const readingWidth = (viewport) =>
+			viewport >= 3200
+				? Math.min(72 * 16, Math.max(64 * 16, viewport * 0.2 + 24 * 16))
+				: viewport >= 1920
+					? Math.min(64 * 16, Math.max(48 * 16, viewport * 0.4))
+					: 48 * 16;
+
+		assert.equal(readingWidth(1920), 48 * 16, "no jump at the first step");
+		assert.equal(readingWidth(3200), 64 * 16, "no jump at the second step");
+		assert.equal(readingWidth(2560), 64 * 16);
+		assert.equal(readingWidth(3840), 72 * 16);
+
+		for (const viewport of [1920, 2560, 3200, 3840]) {
+			assert.ok(
+				readingWidth(viewport) >= readingWidth(viewport - 320),
+				`the rail must not shrink as the viewport grows at ${viewport}px`,
+			);
+		}
+	});
+
 	it("keeps the global grid preference effective on article pages", () => {
 		assert.doesNotMatch(
 			gridScriptsSource,

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -307,14 +307,15 @@ describe("Page layout variant regressions", () => {
 		);
 	});
 
-	it("does not let the post-list grid preference override article pages", () => {
-		assert.match(
+	it("keeps the global grid preference effective on article pages", () => {
+		assert.doesNotMatch(
 			gridScriptsSource,
-			/document\.documentElement\.dataset\.layoutVariant === "post"/,
+			/function getCurrentPostListLayout\(\) \{[\s\S]*?layoutVariant === "post"[\s\S]*?\n\t\}/,
 		);
+		assert.doesNotMatch(rightSidebarLayoutSource, /function isPostPage\(/);
 		assert.match(
 			rightSidebarLayoutSource,
-			/if \(isPostPage\(\)\) \{\s*return "list"/,
+			/function getPostListLayout\(\) \{\s*return isLayoutSwitchEnabled\(\)/,
 		);
 		assert.match(
 			rightSidebarLayoutSource,

--- a/tests/layout-regressions.test.mjs
+++ b/tests/layout-regressions.test.mjs
@@ -178,7 +178,19 @@ describe("Markdown layout regressions", () => {
 
 		assert.match(
 			postContentRailStyles,
-			/--post-wide-rail:\s*min\(var\(--post-wide-content-width\), 100cqi\)/,
+			/--post-wide-available-from-reading-start:\s*calc\([\s\S]*?100cqi \+ var\(--post-reading-rail\)[\s\S]*?\/ 2[\s\S]*?\)/,
+		);
+		assert.match(
+			postContentRailStyles,
+			/--post-wide-rail:\s*min\([\s\S]*?var\(--post-wide-content-width\),[\s\S]*?var\(--post-wide-available-from-reading-start\)[\s\S]*?\)/,
+		);
+		assert.match(
+			postContentRailStyles,
+			/margin-inline-start:\s*0;[\s\S]*?margin-inline-end:\s*calc\(100% - var\(--post-wide-rail\)\)/,
+		);
+		assert.doesNotMatch(
+			postContentRailStyles,
+			/margin-inline:\s*calc\(\(100% - var\(--post-wide-rail\)\) \/ 2\)/,
 		);
 	});
 });


### PR DESCRIPTION
## 关联

Closes #547

设计取舍与「实现和 issue 原提案不一致」的对齐说明已先行发在 issue 里：https://github.com/LyraVoid/Mizuki/issues/547#issuecomment-5236420243 —— **建议先看那条评论再看这个 PR**，本文只描述改了什么、为什么这么改。

基线 `dc0a792`（issue 的源码复核基准，也是当前 `master` HEAD），13 个提交、20 个文件、`+492 / -100`。

---

## 背景：问题出在哪

Mizuki 现在是「全宽 Hero + 固定 90rem 三栏」的结构。90rem = 1440px，在常规桌面下观感很好，但视口超过约 2000 CSS px 之后主体宽度**完全停止增长**，多出来的空间全部变成外围留白：

| CSS 视口 | 改动前页面容器 | 占比 |
| --- | --- | --- |
| 2560 | 1440px | 56% |
| 3840 | 1440px | 38% |

同时中间列在三栏都显示时只有约 816px，减去文章卡片的 `md:px-9` 后 Markdown 实际可用约 744px。**限制普通段落宽度是合理的，但宽表格、代码块、公式、Mermaid 也被压在同一条窄轨道里**，只能自己横向滚动，而右边还空着一大片。

另外两个附带问题：`pageScaling` 通过改根字号实现布局适配，在 1280 → 1281px 会出现 `16px → 13.6px` 的整站字号突变；宽屏下 CardTOC 和外置 SidebarTOC 可能同时常驻，加上浮动 TOC 一共三个目录入口，且 CardTOC 硬编码 `maxLevel: 3` 与其他 TOC 的 `siteConfig.toc.depth` 不一致。

## 核心设计：一个布局变体 + 两条轨道

不复制整套布局组件，而是给 `MainGridLayout` 增加 `layoutVariant`（`home` / `post` / `default`），落到 `<html data-layout-variant>` 上；所有宽屏扩展都写成**只有 `post` 变体才覆盖的 CSS 变量**。首页和其他页面的取值完全不变。

```
--layout-page-width      页面容器      :root = var(--page-width)（90rem，不变）
--layout-sidebar-width   侧栏          :root = 17.5rem（不变）
--post-reading-width     正文阅读轨道   :root = 48rem
```

文章正文和宽内容共享文章卡片的**左内容边缘**，正文停在阅读轨道，宽内容继续向右铺到卡片右内容边缘。

---

## 改动详解

### 1. 解除布局与根字号缩放的耦合

`src/config/siteConfig.ts`、`src/layouts/partials/HeadTags.astro`、`src/types/config.ts`

**为什么**：布局适配不应该改 `document.documentElement.style.fontSize`——它会同时放缩字体、间距、组件和所有 `rem` 容器，还会覆盖用户的浏览器缩放和系统字体设置。而且原逻辑里 `isTabletLike = isTouch || window.innerWidth <= 1280` 这个分支导致 1280px 清除缩放、1281px 立刻套用最低 85%，中间是断的。

**怎么改**：

- `pageScaling.enable` 默认改为 `false`，布局改由 CSS Grid + 媒体查询负责；
- **保留**该功能而不是删除（它对窄桌面压缩 UI 仍有用，删掉属于超出本 issue 范围的行为变更），但去掉 `innerWidth <= 1280` 分支，改成一条连续的 `Math.min(1, Math.max(0.85, currentWidth / targetWidth))`，开着也不会再有断点跳变；
- 关闭时显式 `root.style.removeProperty("font-size")` 并提前 return，避免旧内联样式残留。

`GridScripts.astro` 不再接收 `pageScaling` prop（逻辑已全部收在 `HeadTags` 里，更早执行）。

### 2. 文章页布局变体

`src/layouts/Layout.astro`、`src/layouts/MainGridLayout.astro`、`src/layouts/partials/GridScripts.astro`

**为什么**：首页和文章页对空间的需求本来就不同，但共用一套 Grid 参数。需要一个「首页保持博客三栏气质、文章页单独扩展」的开关，且不能复制布局组件（Banner / Swup / 侧栏逻辑维护成本太高）。

**怎么改**：

```ts
const layoutVariant = postSlug ? "post" : isHomePage ? "home" : "default";
```

传给 `Layout.astro` 渲染成 `<html data-layout-variant>`，同时也标在 `#main-grid` 上。Swup 是无刷新导航，`<html>` 不会重建，所以 `GridScripts` 里新增 `syncLayoutVariant()`，在首次 `requestAnimationFrame`、`DOMContentLoaded` 和 `swup:page:view` 三处同步，从 `#page-overlay-data` 的 `isPost` / `isHome` 读取当前页类型。顺手把重复三遍的「读 localStorage 取布局模式」抽成 `getCurrentPostListLayout()`。

**注意这里没有做的事**：issue 提案 B 建议按视口重排列数（`<1280` 单栏 / `1280～1535` 双栏 / `>=1536` 三栏）。实际没做——列数继续由用户在设置面板保存的 `postListLayout` 决定，布局变体**只管宽度不管列数**。原因见 issue 评论差异 1（简言之：两个来源同时改同一批 DOM 类名会互相覆盖，`d9d5234`、`d282315` 就是踩这个坑的修复）。

### 3. 有上限的宽屏容器、侧栏与外置 TOC 宽度

`src/styles/layout-responsive.css`（新增）、`src/styles/variables.styl`、`src/utils/grid-layout-utils.ts`、`src/styles/banner.css`、`src/pages/anime.astro`、`src/scripts/anime-layout-handler.ts`、`src/scripts/right-sidebar-layout.js`、`src/components/organisms/navigation/Navbar.astro`

**为什么**：直接调大全局 `PAGE_WIDTH` 会让首页和普通段落一起变长；不调又解决不了 4K 下的「小岛化」。所以按页面变体给不同的**带上限的增长策略**。

```css
:root {
  --layout-page-width: var(--page-width);   /* 首页/其他页面：90rem，不变 */
  --layout-sidebar-width: 17.5rem;
}

@media (width >= 1920px) {
  html[data-layout-variant="post"] {
    --layout-page-width: clamp(104rem, 82vw, 132rem);
    --layout-sidebar-width: clamp(17.5rem, 14vw, 19rem);
  }
}
@media (width >= 3200px) {
  html[data-layout-variant="post"] {
    --layout-page-width: clamp(132rem, 64vw, 152rem);
  }
}
```

| CSS 视口 | 改动前 | 改动后（文章页） | 占比 |
| --- | --- | --- | --- |
| 1920 | 1440px | 1664px | 87% |
| 2560 | 1440px | 2099px | 82% |
| 3200 | 1440px | 2112px | 66% |
| 3840 | 1440px | 2432px（132rem 起步 → 152rem 封顶） | 63% |

两档媒体查询在 3200px 处取值相同（都是 2112px），缩放窗口时容器宽度连续，不跳变。

配套把所有硬编码的 `17.5rem` / `1fr` 换成变量：

- `grid-layout-utils.ts`：`lg:grid-cols-[17.5rem_1fr_17.5rem]` → `lg:grid-cols-[var(--layout-sidebar-width)_minmax(0,1fr)_var(--layout-sidebar-width)]`，侧栏 `max-w` 同步；
- 运行时会写内联 `gridTemplateColumns` 的三处（`banner.css` 的 grid 模式 `!important` 规则、`anime.astro` / `anime-layout-handler.ts`、`right-sidebar-layout.js` 的 `hideRightSidebar`）全部改成 `var(--layout-sidebar-width) minmax(0, 1fr)`，否则它们会把 CSS 变量算出来的宽度覆盖回 17.5rem；
- `Navbar.astro` 和 `MainGridLayout` 的 `#top-row`、主面板容器：`max-w-(--page-width)` → `max-w-(--layout-page-width)`，让导航栏和内容岛对齐；
- 外置 TOC 宽度加上下限：`calc((100vw - var(--page-width)) / 2 - 1rem)` → `clamp(0rem, calc((100vw - var(--layout-page-width)) / 2 - 1rem), 22rem)`。原式无下限时接近断点会算出负值/极窄，4K 下又会过宽。

### 4. 每个视口只保留一套常驻 TOC

`src/styles/layout-responsive.css`、`src/components/widgets/card-toc/CardTOC.astro`、`src/layouts/MainGridLayout.astro`

**为什么**：宽屏文章页可能同时出现左侧 CardTOC + 右侧外置 SidebarTOC + 右下浮动 TOC，信息层级重复；且 CardTOC 的 `maxLevel: 3` 是硬编码，和其他 TOC 用的 `siteConfig.toc.depth` 不一致，同一篇文章两个目录层级不同。

**怎么改**：

- 文章页以 CardTOC 为唯一常驻目录，`html[data-layout-variant="post"] #toc-wrapper { display: none }` 隐藏外置 TOC。**只在 `post` 变体隐藏**，组件本身和 `--toc-width` 都保留，其他页面变体照常使用；
- 浮动 TOC 不动，继续作为侧栏隐藏时的主入口和桌面补充入口；
- CardTOC 通过 `data-depth` 把 `siteConfig.toc.depth` 传给客户端脚本，`maxLevel` 改为读它（解析失败回退 3）；
- 外置 TOC 的显示断点由 `2xl` / `lg` 混用统一为 `xl`——原来外层容器是 `hidden 2xl:block`、内层是 `hidden lg:block`，两个断点不一致。

### 5. 阅读轨道 + 宽内容轨道

`src/styles/post-content-rails.css`（新增）、`src/plugins/remark-mark-sectionized.mjs`（新增）、`src/components/misc/Markdown.astro`、`astro.config.mjs`、`src/styles/layout-responsive.css`

这是改动最密集、也返工最多的部分（`03a2c0c` → `5c3d2eb` → `abc0944` → `fcd1a8d` → `7b58f15` 五次）。

**最终形态**：

```css
/* Markdown 根容器占满卡片内容区，把整个宽度暴露给两条轨道 */
html[data-layout-variant="post"] #post-container .markdown-content {
  width: 100%;
  max-width: none !important;
  margin-inline: 0;
}

/* 普通标题/段落/列表：从卡片左边缘起，停在阅读轨道 */
html[data-layout-variant="post"] #post-container
  :where(.markdown-content, .markdown-section) > * {
  max-width: min(100%, var(--post-reading-width));
  margin-inline-start: 0;
  margin-inline-end: auto;
}

/* 宽内容：同一左边缘，铺到卡片右内容边缘 */
html[data-layout-variant="post"] #post-container
  :where(.markdown-content, .markdown-section) > :is(
    .table-wrapper, .expressive-code, .rehype-code-group,
    .katex-display, .mermaid-diagram-container, .image-grid,
    p:has(> .katex-display)
  ) {
  box-sizing: border-box;
  width: 100%;
  max-width: none;
  margin-inline-start: 0;
  margin-inline-end: 0;
}
```

阅读轨道本身也随视口增长：

```css
:root { --post-reading-width: 48rem; }
@media (width >= 1920px) { --post-reading-width: clamp(48rem, 40vw, 64rem); }
@media (width >= 3200px) { --post-reading-width: clamp(64rem, 20vw + 24rem, 72rem); }
```

**四次返工分别解决了什么**：

1. **左对齐，不居中**（`5c3d2eb`）。最初按提案做的是居中轨道 + 负外边距扩展，实际效果是宽内容围绕中线向两侧长，代码块左边缘和段落左边缘对不齐，滚动时视觉漂移很明显。改成两条轨道共享左边缘、只向右扩展。
2. **根容器放开到卡片满宽**（`abc0944`）。此前根容器自己带 48rem 上限，宽内容再怎么设 `width: 100%` 也会被父级截断，只能靠负外边距和 `cqi` 硬顶出去。改成根容器满宽、轨道下放到子元素，负边距/`cqi`/72rem 上限那套全部删掉。
3. **保护嵌套语法的缩进**（`fcd1a8d`）。`remark-sectionize` 会给每一级标题包一层 `<section>`，用裸 `section` 选择器套轨道会让正文**阶梯式右移**。新增 `remark-mark-sectionized` 插件（注册在 `remarkSectionize` 之后），只给自动生成的 section 打 `markdown-section` 类；轨道只作用于 Markdown 根节点和标记 section 的**直属**子元素。这样列表项、块引用、admonition 内部的代码和表格继续服从各自父级缩进，不会被全局宽内容规则拉回卡片左边缘；作者手写的 `<section>` HTML 也不受影响（插件只处理 `node.data.hName === "section"` 的 mdast 节点，`type: "html"` 的原始节点跳过）。
4. **正文也吃到宽屏扩展**（`7b58f15`）。前三次只让代码块/表格变宽，正文仍钉在 48rem——2560px 下卡片内容区约 1330px，正文只占 58%，右边空 560px，视觉上非常割裂。改成随视口增长后：

| CSS 视口 | 正文轨道 | 卡片内容区(约) | 占比 |
| --- | --- | --- | --- |
| 1920 | 48rem / 768px | 1000px | 77% |
| 2560 | 64rem / 1024px | 1330px | 77% |
| 3200 | 64rem / 1024px | 1400px | 73% |
| 3840 | 72rem / 1152px | 1720px | 67% |

两档都以上一档的取值作为下界起步（`40vw` 在 1920px 恰好 = 48rem，`20vw + 24rem` 在 3200px 恰好 = 64rem），所以轨道宽度在两个断点处都连续。

`post-content-rails.css` 由 `Markdown.astro` 导入，跟随每一条 Markdown 渲染路径（包括加密文章），不挂在可选的 Encryptor 上。

### 6. 防止宽内容撑出页面级横向滚动条

`src/utils/grid-layout-utils.ts`、`src/scripts/right-sidebar-layout.js`

**为什么**：让宽内容变宽以后，Grid 的 `1fr` 会被内容撑大（`1fr` 的 min 值是 `auto`），整个 `#main-grid` 溢出，`body` 出现横向滚动条——这正好违反 issue 验收标准里的「宽内容溢出时只在自身容器内滚动」。

**怎么改**：所有 `1fr` 改成 `minmax(0,1fr)`，主内容类补 `min-w-0`（`transition-swup-fade overflow-hidden min-w-0 w-full`）。

**`overflow-hidden` 保留**：提案 D 写的是「需要同步处理主内容的 `overflow-hidden`，避免宽轨道被裁剪」，实际结论相反——不用去掉，`minmax(0,1fr)` + `min-w-0` 就够了；去掉反而会让宽内容把整个页面网格撑破。

另外 `right-sidebar-layout.js` 的 `layoutChange` 监听原本读 `event.detail.layout` 并据此显隐右侧栏，导致文章列表页发出的模式事件会覆盖文章页侧栏状态（`d9d5234`）。改成统一走 `applyCurrentPageLayout()`，四个入口（`layoutChange`、`storage`、`astro:page-load`、`swup:contentReplaced`）都重新读当前实际布局，不信任事件里带的值。

---

## 变更文件

**新增（3）**

- `src/styles/layout-responsive.css` — 布局变量与文章页宽屏断点
- `src/styles/post-content-rails.css` — 阅读轨道与宽内容轨道
- `src/plugins/remark-mark-sectionized.mjs` — 标记自动分节

**布局与脚本（8）**

`Layout.astro`、`MainGridLayout.astro`、`GridScripts.astro`、`HeadTags.astro`、`grid-layout-utils.ts`、`right-sidebar-layout.js`、`anime-layout-handler.ts`、`anime.astro`

**样式与组件（5）**

`variables.styl`、`banner.css`、`Navbar.astro`、`CardTOC.astro`、`Markdown.astro`

**配置与测试（4）**

`siteConfig.ts`、`types/config.ts`、`astro.config.mjs`、`tests/layout-regressions.test.mjs`

## 测试

`tests/layout-regressions.test.mjs` 新增约 250 行断言，`pnpm test` 全绿（38 passed / 0 failed）。覆盖：

- 布局变体在服务端计算、渲染到 `<html>`、并在 `swup:page:view` 同步；
- 宽屏容器与侧栏的具体 clamp 取值，以及 2560 / 3840 下的占比复算（防止再退回保守的固定上限）；
- 阅读轨道左对齐、根容器满宽、宽内容贴右边缘、嵌套 section 隔离；
- 阅读轨道在 1920 / 3200 两个断点的连续性，2560 → 64rem、3840 → 72rem，以及随视口单调不缩；
- 每个视口只有一套常驻 TOC、所有 TOC 共享 `siteConfig.toc.depth`；
- `pageScaling` 默认关闭且不存在 1280/1281 分支；
- 文章页仍然响应全局 grid/list 偏好（防止再次出现强制回退）；
- `remark-mark-sectionized` 只标记 mdast 的 section 节点，跳过作者手写的 `<section>` HTML。

**未覆盖、需要以维护者实机测试为准的部分（如实说明）**：

- 多视口回归是**源码级断言 + 数值复算**，加上 2560px 下的人工目视核对。**没有跑真实浏览器的多视口自动化**，1366px 与 3840px 未实机验证；
- 改动全部收在 `>= 1920px` 媒体查询和 `post` 变体内，理论上不触及移动端和各 wallpaper mode，但**没有做系统性回归验证**。

## 影响面

- 首页与其他页面：`--layout-page-width` 仍等于 `var(--page-width)`（90rem），视觉无变化；
- `< 1920px` 的桌面：仅涉及硬编码 `17.5rem` → 变量、`1fr` → `minmax(0,1fr)` 的等价替换，取值不变；
- **行为变更 1**：`pageScaling.enable` 默认值 `true` → `false`。升级后如果依赖旧缩放行为，在 `siteConfig.ts` 里手动开回来即可，且开回来也不再有 1280/1281 跳变；
- **行为变更 2**：文章页不再渲染最右侧外置 TOC；外置 TOC 在其他页面的显示断点由 `2xl` 统一为 `xl`；
- **行为变更 3**：CardTOC 的目录深度由硬编码 3 改为跟随 `siteConfig.toc.depth`，配置了其他深度的站点目录层级会变。

## 想请评审先确认的三点取舍

这三处的实际取值都超出了 issue 原提案给的区间，改回去技术上都很简单，但会牺牲对应的效果：

1. **正文行长**：2560px 下 1024px、3840px 下 1152px。偏激进的话把 `64rem` 降回 `56rem` 即可，代价是右侧留白回到约 300px。
2. **容器上限**：132rem / 152rem vs 提案的 104～112rem。回到 112rem 封顶没问题，但 2K 下的「小岛化」基本不会改善（112rem 在 2560px 下只占 70%）。
3. **列数职责划分**：目前是「列数归 `postListLayout` 用户偏好、宽度归视口」。如果希望文章页按视口硬编码列数，需要先决定它和 `postListLayout` 谁优先。

具体断点和数值都在 `src/styles/layout-responsive.css` 一个文件里，调整成本很低，按维护者的视觉测试结果改即可。
