### PR TITLE
feat(config): 配置项与内容统一分离——支持从内容仓库覆盖配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ pnpm-debug.log*
 /content/
 *.backup
 
+# config overrides synced from the content repository
+/src/config/overrides/
+
 # Large zip files
 *.zip
 

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ pnpm-debug.log*
 # config overrides synced from the content repository
 /src/config/overrides/
 
+# output of `pnpm export-config`
+/overrides-export/
+
 # Large zip files
 *.zip
 

--- a/docs/CONTENT_REPOSITORY.md
+++ b/docs/CONTENT_REPOSITORY.md
@@ -24,8 +24,21 @@ Mizuki-Content/
 │   ├── albums/         # 相册图片
 │   ├── diary/          # 日记图片
 │   └── posts/          # 文章图片
+├── overrides/          # 配置覆盖（可选，见 CONTENT_SEPARATION.md）
+│   ├── siteConfig.ts
+│   └── profileConfig.ts
 └── README.md
 ```
+
+各目录同步到代码仓库的位置：
+
+| 内容仓库 | 代码仓库 |
+| --- | --- |
+| `posts/` | `src/content/posts/` |
+| `spec/` | `src/content/spec/` |
+| `data/` | `src/data/` |
+| `images/` | `public/images/` |
+| `overrides/` | `src/config/overrides/` |
 
 ## 🚀 快速开始
 

--- a/docs/CONTENT_SEPARATION.md
+++ b/docs/CONTENT_SEPARATION.md
@@ -261,6 +261,75 @@ CONTENT_REPO_URL=git@github.com:your-username/Mizuki-Content-Private.git
 
 文件名不在名单内会在构建期报错并列出合法名单，不会静默失效。
 
+### 迁移步骤：把已有配置搬进内容仓库
+
+如果你已经在 `src/config/` 里改了一堆个人配置，用 `pnpm export-config` 一键抽出来，不用手抄。
+
+**前置条件**：代码仓库有一个指向「配置还是上游原版」的 git remote。fork 用户通常已经有了：
+
+```bash
+git remote -v          # 确认有 upstream 或 origin 指向上游
+git fetch upstream     # 拉一下，保证基准是最新的
+```
+
+**第 1 步：导出个人配置**
+
+```bash
+pnpm export-config
+```
+
+脚本会自动挑基准（依次尝试 `upstream/master`、`upstream/main`、`origin/master`、`origin/main`），把当前 `src/config/` 与那一版逐字段比对，只把**你改过的字段**写进 `overrides-export/`：
+
+```
+上游基准：upstream/master (453cc42)
+导出目录：overrides-export
+
+  已导出 siteConfig.ts（16 个顶层键）
+  已导出 profileConfig.ts（3 个顶层键）
+  已导出 navBarConfig.ts（1 个顶层键）
+  ...
+与上游一致、无需覆盖：sakuraConfig、licenseConfig、markdownConfig、...
+```
+
+基准不对时用 `--ref` 手动指定，想直接写进内容仓库用 `--out`：
+
+```bash
+pnpm export-config --ref=upstream/v9.0.0
+pnpm export-config --out=../Mizuki-Content/overrides
+```
+
+导出前脚本会自检 `deepMerge(上游默认, 覆盖) === 你当前的配置`，对不上会明确报出是哪个配置、差在哪，不会生成一份「看着像但装上不一样」的覆盖。
+
+**第 2 步：放进内容仓库**
+
+```bash
+cp overrides-export/*.ts ../Mizuki-Content/overrides/
+```
+
+**第 3 步：把代码仓库的配置还原成上游原版**
+
+这一步是收益的来源——`src/config/` 不再有你的改动，之后合并上游就不会在配置文件上冲突：
+
+```bash
+git checkout upstream/master -- src/config/
+```
+
+**第 4 步：同步并校验**
+
+```bash
+pnpm sync-content     # overrides/ -> src/config/overrides/
+pnpm type-check       # 覆盖文件的类型检查在这一步做
+pnpm build
+```
+
+`pnpm type-check` 通过 + 站点渲染结果和之前一致，就说明搬迁成功。
+
+**第 5 步：让内容仓库的配置改动能触发部署**
+
+见下面的[触发部署](#触发部署)。
+
+**回滚**：覆盖机制是纯叠加的，删掉 `overrides/` 里的文件、重新 `pnpm sync-content`，配置就回到上游默认值；想完全退回旧方式，把个人配置写回 `src/config/*.ts` 即可，代码不需要改。
+
 ### 写法
 
 只写你想改的字段，其余自动取上游默认值：
@@ -287,6 +356,7 @@ export default {
 
 - 必须是 `export default`，命名导出不会被识别（构建期报错）；
 - 用 `DeepPartial<XxxConfig>` 而不是 `Partial<XxxConfig>`：`Partial` 只让顶层键可选，写 `carousel: { interval: 8 }` 会因为缺少 `enable`、`switchable` 而报错；
+- `navBarConfig.links` 里的预设项是枚举，要写 `LinkPreset.Home` 并 `import { LinkPreset } from "../../types/config"`，不能写裸数字；
 - 相对路径 `../../types/config` 是同步到 `src/config/overrides/` 之后的位置。内容仓库本身没有 TypeScript 环境，类型检查在代码仓库执行 `pnpm type-check` 时进行。
 
 ### 合并语义
@@ -319,10 +389,11 @@ on:
 
 ### 已知限制
 
+- **深合并表达不了「删除」。** 覆盖只能改值或加字段，没法把上游默认里的某个键去掉。`pnpm export-config` 遇到这种情况会明确报出来，需要手工处理。
 - **评论语言不会自动跟随 `siteConfig.lang`。** `src/config/commentConfig.ts` 在模块顶层引用 `siteConfig.ts` 里的语言常量填充 Twikoo / Giscus 的 `lang`，覆盖 `siteConfig.lang` 时需要同时提供 `overrides/commentConfig.ts` 覆盖对应字段。
 - **读取配置请统一走 `@/config` 入口。** 直接 `import { siteConfig } from "@/config/siteConfig"` 会绕过合并，拿到未覆盖的默认值。
 - **开发服务器不监听内容仓库。** `src/config/overrides/` 是指向内容目录的链接，改完覆盖文件需要重启 `pnpm dev`。
-- **`scripts/compress-fonts/` 暂不读取覆盖值**，该目录是独立的手动工具，不在 `pnpm build` 流程内。
+- **`scripts/compress-fonts/` 暂不读取覆盖值**，该目录是独立的手动工具，不在 `pnpm build` 流程内。番剧数据脚本（`update-anime` / `update-bangumi` / `update-bilibili`）已经会优先读覆盖值。
 
 ---
 
@@ -479,6 +550,7 @@ CONTENT_REPO_URL=https://YOUR_TOKEN@github.com/your-username/Mizuki-Content-Priv
 |------|------|
 | `pnpm run init-content` | 运行交互式初始化向导 |
 | `pnpm run sync-content` | 手动同步内容仓库 |
+| `pnpm run export-config` | 导出个人配置为 `overrides/` 覆盖文件 |
 | `pnpm run check` | 运行 Astro 诊断 |
 | `pnpm run type-check` | 运行 TypeScript 类型检查 |
 | `pnpm dev` | 启动开发服务器 (自动同步) |

--- a/docs/CONTENT_SEPARATION.md
+++ b/docs/CONTENT_SEPARATION.md
@@ -228,7 +228,7 @@ CONTENT_REPO_URL=git@github.com:your-username/Mizuki-Content-Private.git
 
 配置覆盖把个人配置值也搬进内容仓库：`src/config/*.ts` 保持上游原版，个人值写在内容仓库的 `overrides/` 里，构建时深合并。跟进上游更新时，配置文件不再产生冲突；上游**新增**配置项自动生效，只有上游**修改结构**时才会暴露问题，且表现为编译期类型错误。
 
-**这是可选功能。** 不创建 `overrides/` 目录时，所有配置等同于上游默认值，行为与现状完全一致。
+**这是可选功能，也是实验性功能。** 不创建 `overrides/` 目录时，所有配置等同于上游默认值，行为与现状完全一致；但启用前请阅读[迁移步骤](#迁移步骤把已有配置搬进内容仓库)中的注意事项。
 
 ### 工作方式
 
@@ -263,72 +263,42 @@ CONTENT_REPO_URL=git@github.com:your-username/Mizuki-Content-Private.git
 
 ### 迁移步骤：把已有配置搬进内容仓库
 
-如果你已经在 `src/config/` 里改了一堆个人配置，用 `pnpm export-config` 一键抽出来，不用手抄。
+> ⚠️ **实验性功能，慎用**：配置分离（overrides）目前仍处于早期阶段，测试覆盖的场景有限，边界情况未必都验证到。迁移前请先提交或备份当前配置，迁移后务必完整校验一遍；重要站点建议先观察一段时间再决定是否长期使用。
 
-**前置条件**：代码仓库有一个指向「配置还是上游原版」的 git remote。fork 用户通常已经有了：
+如果你已经改过 `src/config/` 里的配置，可以用 `pnpm export-config` 自动抽出「与上游不同的字段」生成覆盖文件，不需要手抄。
+
+**前置条件**：代码仓库里有一个「配置还是上游原版」的 git remote 可作基准。fork 用户通常已经有了：
 
 ```bash
-git remote -v          # 确认有 upstream 或 origin 指向上游
-git fetch upstream     # 拉一下，保证基准是最新的
+git remote -v          # 确认有 upstream（或 origin）指向上游仓库
+git fetch upstream     # 更新基准
 ```
 
-**第 1 步：导出个人配置**
+**迁移流程**：
 
 ```bash
+# 1. 导出个人配置：与上游基准逐字段比对，结果写入 overrides-export/
 pnpm export-config
-```
 
-脚本会自动挑基准（依次尝试 `upstream/master`、`upstream/main`、`origin/master`、`origin/main`），把当前 `src/config/` 与那一版逐字段比对，只把**你改过的字段**写进 `overrides-export/`：
+# 2. 把覆盖文件放进内容仓库
+cp overrides-export/*.ts <内容仓库>/overrides/
 
-```
-上游基准：upstream/master (453cc42)
-导出目录：overrides-export
-
-  已导出 siteConfig.ts（16 个顶层键）
-  已导出 profileConfig.ts（3 个顶层键）
-  已导出 navBarConfig.ts（1 个顶层键）
-  ...
-与上游一致、无需覆盖：sakuraConfig、licenseConfig、markdownConfig、...
-```
-
-基准不对时用 `--ref` 手动指定，想直接写进内容仓库用 `--out`：
-
-```bash
-pnpm export-config --ref=upstream/v9.0.0
-pnpm export-config --out=../Mizuki-Content/overrides
-```
-
-导出前脚本会自检 `deepMerge(上游默认, 覆盖) === 你当前的配置`，对不上会明确报出是哪个配置、差在哪，不会生成一份「看着像但装上不一样」的覆盖。
-
-**第 2 步：放进内容仓库**
-
-```bash
-cp overrides-export/*.ts ../Mizuki-Content/overrides/
-```
-
-**第 3 步：把代码仓库的配置还原成上游原版**
-
-这一步是收益的来源——`src/config/` 不再有你的改动，之后合并上游就不会在配置文件上冲突：
-
-```bash
+# 3. 还原代码仓库的配置为上游原版
+#    这一步是收益来源：src/config/ 不再有你的改动，之后合并上游不会在配置上冲突
 git checkout upstream/master -- src/config/
+
+# 4. 同步并校验
+pnpm sync-content && pnpm type-check && pnpm build
 ```
 
-**第 4 步：同步并校验**
+**要点**：
 
-```bash
-pnpm sync-content     # overrides/ -> src/config/overrides/
-pnpm type-check       # 覆盖文件的类型检查在这一步做
-pnpm build
-```
+- 导出基准自动挑选（依次尝试 `upstream/master`、`upstream/main`、`origin/master`、`origin/main`），不对时用 `--ref=<git-ref>` 指定；`--out=<目录>` 可以直接写进内容仓库。
+- 导出前脚本会自检「覆盖合并回去是否等于你当前的配置」，无法还原时会报出具体原因，不会生成不一致的覆盖文件。
+- 校验标准：`type-check` 通过，且构建出的站点与迁移前渲染一致。
+- 内容仓库如果配置了部署触发工作流，记得把 `overrides/**` 加进 `paths`，见下面的[触发部署](#触发部署)。
 
-`pnpm type-check` 通过 + 站点渲染结果和之前一致，就说明搬迁成功。
-
-**第 5 步：让内容仓库的配置改动能触发部署**
-
-见下面的[触发部署](#触发部署)。
-
-**回滚**：覆盖机制是纯叠加的，删掉 `overrides/` 里的文件、重新 `pnpm sync-content`，配置就回到上游默认值；想完全退回旧方式，把个人配置写回 `src/config/*.ts` 即可，代码不需要改。
+**回滚**：删掉内容仓库 `overrides/` 里的文件、重新 `pnpm sync-content`，配置即回到上游默认值；想完全退回直接修改 `src/config/*.ts` 的旧方式也可以，代码不需要任何改动。
 
 ### 写法
 

--- a/docs/CONTENT_SEPARATION.md
+++ b/docs/CONTENT_SEPARATION.md
@@ -7,6 +7,7 @@
 - [快速开始](#-快速开始)
 - [ENABLE_CONTENT_SYNC 控制开关](#-enable_content_sync-控制开关)
 - [配置方式](#-配置方式)
+- [配置覆盖 (overrides)](#-配置覆盖-overrides)
 - [私有仓库](#-私有仓库配置)
 - [CI/CD 部署](#-cicd-部署)
 - [常用命令](#-常用命令)
@@ -216,6 +217,112 @@ CONTENT_REPO_URL=https://github.com/your-username/Mizuki-Content.git
 ENABLE_CONTENT_SYNC=true
 CONTENT_REPO_URL=git@github.com:your-username/Mizuki-Content-Private.git
 ```
+
+---
+
+## 🧩 配置覆盖 (overrides)
+
+### 解决什么问题
+
+文章和数据可以放进内容仓库，但 `src/config/` 下的配置项默认必须直接改代码仓库的源文件。对于 fork 上游、定期合并上游更新的用户，配置文件是冲突重灾区：上游每次调整配置结构，都会和本地的个人值冲突。
+
+配置覆盖把个人配置值也搬进内容仓库：`src/config/*.ts` 保持上游原版，个人值写在内容仓库的 `overrides/` 里，构建时深合并。跟进上游更新时，配置文件不再产生冲突；上游**新增**配置项自动生效，只有上游**修改结构**时才会暴露问题，且表现为编译期类型错误。
+
+**这是可选功能。** 不创建 `overrides/` 目录时，所有配置等同于上游默认值，行为与现状完全一致。
+
+### 工作方式
+
+```
+内容仓库 overrides/  ──sync-content──>  代码仓库 src/config/overrides/
+                                                    │
+                     src/config/index.ts 在导出前深合并 ↓
+
+              最终配置 = deepMerge(上游默认配置, 同名覆盖文件的 default 导出)
+```
+
+`src/config/overrides/` 已加入 `.gitignore`，不会进入代码仓库的提交历史。
+
+### 目录与命名
+
+**覆盖文件名 = 被覆盖的导出常量名**（注意有几个和上游文件名不同）：
+
+```
+内容仓库
+└── overrides/
+    ├── siteConfig.ts        →  siteConfig            (上游 siteConfig.ts)
+    ├── profileConfig.ts     →  profileConfig         (上游 profileConfig.ts)
+    ├── navBarConfig.ts      →  navBarConfig          (上游 navBarConfig.ts)
+    ├── musicPlayerConfig.ts →  musicPlayerConfig     (上游 musicConfig.ts)
+    ├── sakuraConfig.ts      →  sakuraConfig          (上游 effectsConfig.ts)
+    └── ...
+```
+
+可覆盖的 18 个配置：`announcementConfig`、`commentConfig`、`expressiveCodeConfig`、`footerConfig`、`fullscreenWallpaperConfig`、`licenseConfig`、`markdownConfig`、`musicPlayerConfig`、`navBarConfig`、`permalinkConfig`、`pioConfig`、`profileConfig`、`randomPostsConfig`、`relatedPostsConfig`、`sakuraConfig`、`shareConfig`、`sidebarLayoutConfig`、`siteConfig`。
+
+文件名不在名单内会在构建期报错并列出合法名单，不会静默失效。
+
+### 写法
+
+只写你想改的字段，其余自动取上游默认值：
+
+```ts
+// overrides/siteConfig.ts
+import type { DeepPartial, SiteConfig } from "../../types/config";
+
+export default {
+	title: "我的站点",
+	siteURL: "https://example.com/",
+	lang: "zh_CN",
+	banner: {
+		src: {
+			desktop: ["/images/banner/desktop.webp"],
+			mobile: ["/images/banner/mobile.webp"],
+		},
+		carousel: { interval: 8 },
+	},
+} satisfies DeepPartial<SiteConfig>;
+```
+
+要点：
+
+- 必须是 `export default`，命名导出不会被识别（构建期报错）；
+- 用 `DeepPartial<XxxConfig>` 而不是 `Partial<XxxConfig>`：`Partial` 只让顶层键可选，写 `carousel: { interval: 8 }` 会因为缺少 `enable`、`switchable` 而报错；
+- 相对路径 `../../types/config` 是同步到 `src/config/overrides/` 之后的位置。内容仓库本身没有 TypeScript 环境，类型检查在代码仓库执行 `pnpm type-check` 时进行。
+
+### 合并语义
+
+| 情况 | 行为 |
+| --- | --- |
+| 双方都是普通对象 | 深合并，覆盖值只影响写到的字段 |
+| 数组 | 整体替换，不拼接 |
+| 标量、`null` | 整体替换 |
+| 覆盖值里显式写 `undefined` 的键 | 跳过，保留默认值 |
+| 没有对应覆盖文件 | 原样使用上游默认值 |
+
+举例：默认 `banner.carousel` 是 `{ enable: true, interval: 3, switchable: true }`，覆盖里只写 `{ interval: 8 }`，结果是 `{ enable: true, interval: 8, switchable: true }`；而默认 `banner.src.desktop` 有 4 张图，覆盖里写 1 张，结果就是 1 张。
+
+### 触发部署
+
+内容仓库的 `trigger-build.yml` 需要把 `overrides/**` 加进 `paths`，否则只改配置不会触发站点重新构建：
+
+```yaml
+on:
+  push:
+    branches: [main]
+    paths:
+      - "posts/**"
+      - "spec/**"
+      - "data/**"
+      - "images/**"
+      - "overrides/**"
+```
+
+### 已知限制
+
+- **评论语言不会自动跟随 `siteConfig.lang`。** `src/config/commentConfig.ts` 在模块顶层引用 `siteConfig.ts` 里的语言常量填充 Twikoo / Giscus 的 `lang`，覆盖 `siteConfig.lang` 时需要同时提供 `overrides/commentConfig.ts` 覆盖对应字段。
+- **读取配置请统一走 `@/config` 入口。** 直接 `import { siteConfig } from "@/config/siteConfig"` 会绕过合并，拿到未覆盖的默认值。
+- **开发服务器不监听内容仓库。** `src/config/overrides/` 是指向内容目录的链接，改完覆盖文件需要重启 `pnpm dev`。
+- **`scripts/compress-fonts/` 暂不读取覆盖值**，该目录是独立的手动工具，不在 `pnpm build` 流程内。
 
 ---
 

--- a/docs/CONTENT_SEPARATION.md
+++ b/docs/CONTENT_SEPARATION.md
@@ -284,7 +284,7 @@ pnpm export-config
 cp overrides-export/*.ts <内容仓库>/overrides/
 
 # 3. 还原代码仓库的配置为上游原版
-#    这一步是收益来源：src/config/ 不再有你的改动，之后合并上游不会在配置上冲突
+#    还原后 src/config/ 不再有个人改动，之后合并上游不会在配置上冲突
 git checkout upstream/master -- src/config/
 
 # 4. 同步并校验
@@ -339,7 +339,7 @@ export default {
 | 覆盖值里显式写 `undefined` 的键 | 跳过，保留默认值 |
 | 没有对应覆盖文件 | 原样使用上游默认值 |
 
-举例：默认 `banner.carousel` 是 `{ enable: true, interval: 3, switchable: true }`，覆盖里只写 `{ interval: 8 }`，结果是 `{ enable: true, interval: 8, switchable: true }`；而默认 `banner.src.desktop` 有 4 张图，覆盖里写 1 张，结果就是 1 张。
+举例：默认 `banner.carousel` 是 `{ enable: true, interval: 3, switchable: true }`，覆盖里只写 `{ interval: 8 }`，结果是 `{ enable: true, interval: 8, switchable: true }`；数组则是整体替换，比如覆盖 `banner.src.desktop` 只写 1 张图，结果就是这 1 张，不会与默认列表拼接。
 
 ### 触发部署
 

--- a/docs/CONTENT_SEPARATION.md
+++ b/docs/CONTENT_SEPARATION.md
@@ -392,7 +392,7 @@ on:
 - **深合并表达不了「删除」。** 覆盖只能改值或加字段，没法把上游默认里的某个键去掉。`pnpm export-config` 遇到这种情况会明确报出来，需要手工处理。
 - **评论语言不会自动跟随 `siteConfig.lang`。** `src/config/commentConfig.ts` 在模块顶层引用 `siteConfig.ts` 里的语言常量填充 Twikoo / Giscus 的 `lang`，覆盖 `siteConfig.lang` 时需要同时提供 `overrides/commentConfig.ts` 覆盖对应字段。
 - **读取配置请统一走 `@/config` 入口。** 直接 `import { siteConfig } from "@/config/siteConfig"` 会绕过合并，拿到未覆盖的默认值。
-- **开发服务器不监听内容仓库。** `src/config/overrides/` 是指向内容目录的链接，改完覆盖文件需要重启 `pnpm dev`。
+- **开发服务器不监听内容仓库。** `src/config/overrides/` 在每次 dev/build 前由 sync-content 从内容仓库复制而来；dev 运行中修改覆盖文件需要重启 `pnpm dev` 才会重新同步。
 - **`scripts/compress-fonts/` 暂不读取覆盖值**，该目录是独立的手动工具，不在 `pnpm build` 流程内。番剧数据脚本（`update-anime` / `update-bangumi` / `update-bilibili`）已经会优先读覆盖值。
 
 ---

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "sync-content": "node scripts/sync-content.js",
     "init-content": "node scripts/init-content-repo.js",
+    "export-config": "node --experimental-transform-types scripts/export-config.mjs",
     "predev": "node scripts/sync-content.js || true",
     "prebuild": "node scripts/sync-content.js || true",
     "dev": "astro dev",

--- a/scripts/export-config.mjs
+++ b/scripts/export-config.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+
+/**
+ * 一键导出个性化配置
+ *
+ * 把当前 src/config/ 与上游原版逐项比对，只把「你改过的字段」导出成
+ * overrides/ 覆盖文件，供内容仓库使用。
+ *
+ * 用法：
+ *   pnpm export-config                  # 自动挑选上游基准
+ *   pnpm export-config --ref=upstream/master
+ *   pnpm export-config --out=../MyBlog-Content/overrides
+ *
+ * 基准 ref 必须指向「配置还是上游原版」的提交，脚本从 git 里取出那一版
+ * 配置做对比，因此不需要你在磁盘上另留一份干净副本。
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import { register } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+
+import { deepMerge } from "../src/config/deepMerge.ts";
+import { LinkPreset } from "../src/types/config.ts";
+
+// 配置文件里存在 `from "../types/config"` 这类省略扩展名的写法，Node 自身
+// 解析不了，补一个 resolve 钩子。
+register(
+	`data:text/javascript,${encodeURIComponent(`
+		export async function resolve(specifier, context, next) {
+			try {
+				return await next(specifier, context);
+			} catch (error) {
+				if (specifier.startsWith(".") && !/\\.[cm]?[jt]s$/.test(specifier)) {
+					return next(specifier + ".ts", context);
+				}
+				throw error;
+			}
+		}
+	`)}`,
+);
+
+const rootDir = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+);
+
+/** 覆盖文件名 = 导出常量名，与 src/config/overrideLoader.ts 的名单保持一致 */
+const CONFIGS = [
+	["announcementConfig", "announcementConfig", "AnnouncementConfig"],
+	["backgroundWallpaper", "fullscreenWallpaperConfig", "FullscreenWallpaperConfig"],
+	["commentConfig", "commentConfig", "CommentConfig"],
+	["effectsConfig", "sakuraConfig", "SakuraConfig"],
+	["expressiveCodeConfig", "expressiveCodeConfig", "ExpressiveCodeConfig"],
+	["footerConfig", "footerConfig", "FooterConfig"],
+	["licenseConfig", "licenseConfig", "LicenseConfig"],
+	["markdownConfig", "markdownConfig", "MarkdownEnhancementConfig"],
+	["musicConfig", "musicPlayerConfig", "MusicPlayerConfig"],
+	["navBarConfig", "navBarConfig", "NavBarConfig"],
+	["permalinkConfig", "permalinkConfig", "PermalinkConfig"],
+	["pioConfig", "pioConfig", "PioConfig"],
+	["profileConfig", "profileConfig", "ProfileConfig"],
+	["randomPostsConfig", "randomPostsConfig", "RandomPostsConfig"],
+	["relatedPostsConfig", "relatedPostsConfig", "RelatedPostsConfig"],
+	["shareConfig", "shareConfig", "ShareConfig"],
+	["sidebarConfig", "sidebarLayoutConfig", "SidebarLayoutConfig"],
+	["siteConfig", "siteConfig", "SiteConfig"],
+];
+
+/** MarkdownEnhancementConfig 声明在配置文件自身，不在 types/config.ts */
+const TYPE_IN_CONFIG_FILE = new Set(["MarkdownEnhancementConfig"]);
+
+const LINK_PRESET_NAMES = new Map(
+	Object.entries(LinkPreset)
+		.filter(([, value]) => typeof value === "number")
+		.map(([name, value]) => [value, name]),
+);
+
+function parseArgs(argv) {
+	const args = { ref: null, out: path.join(rootDir, "overrides-export") };
+	for (const arg of argv) {
+		if (arg.startsWith("--ref=")) args.ref = arg.slice(6);
+		else if (arg.startsWith("--out=")) args.out = path.resolve(rootDir, arg.slice(6));
+		else {
+			console.error(`未知参数：${arg}`);
+			process.exit(1);
+		}
+	}
+	return args;
+}
+
+function git(args, options = {}) {
+	return execFileSync("git", args, {
+		cwd: rootDir,
+		encoding: "utf-8",
+		stdio: ["ignore", "pipe", "pipe"],
+		...options,
+	});
+}
+
+function refExists(ref) {
+	try {
+		git(["rev-parse", "--verify", "--quiet", `${ref}^{commit}`]);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function resolveBaseRef(requested) {
+	if (requested) {
+		if (!refExists(requested)) {
+			console.error(`✘ 找不到 git ref：${requested}`);
+			process.exit(1);
+		}
+		return requested;
+	}
+
+	const candidates = ["upstream/master", "upstream/main", "origin/master", "origin/main"];
+	const found = candidates.find(refExists);
+	if (!found) {
+		console.error("✘ 找不到可用的上游基准，请用 --ref=<git-ref> 指定");
+		console.error(`   已尝试：${candidates.join("、")}`);
+		process.exit(1);
+	}
+	return found;
+}
+
+/** 把某个 ref 下的 src/config 与 src/types 取出到临时目录 */
+function materializeBaseTree(ref) {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mizuki-base-"));
+	const files = git(["ls-tree", "-r", "--name-only", ref, "src/config", "src/types"])
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.endsWith(".ts"));
+
+	for (const file of files) {
+		const target = path.join(dir, file);
+		fs.mkdirSync(path.dirname(target), { recursive: true });
+		fs.writeFileSync(target, git(["show", `${ref}:${file}`]));
+	}
+	return dir;
+}
+
+function isPlainObject(value) {
+	if (typeof value !== "object" || value === null) return false;
+	const proto = Object.getPrototypeOf(value);
+	return proto === Object.prototype || proto === null;
+}
+
+/** 只保留与上游不同的字段 */
+function minimalDiff(base, mine) {
+	if (!isPlainObject(base) || !isPlainObject(mine)) {
+		return isDeepStrictEqual(base, mine) ? undefined : mine;
+	}
+
+	const diff = {};
+	for (const [key, value] of Object.entries(mine)) {
+		const sub = minimalDiff(base[key], value);
+		if (sub !== undefined) diff[key] = sub;
+	}
+	return Object.keys(diff).length ? diff : undefined;
+}
+
+/** 深合并表达不了「上游有、你删掉」的键，单独找出来提示 */
+function findRemovedPaths(base, mine, trail = [], out = []) {
+	if (!isPlainObject(base) || !isPlainObject(mine)) return out;
+	for (const key of Object.keys(base)) {
+		if (!(key in mine) || mine[key] === undefined) {
+			out.push([...trail, key].join("."));
+		} else {
+			findRemovedPaths(base[key], mine[key], [...trail, key], out);
+		}
+	}
+	return out;
+}
+
+function formatKey(key) {
+	return /^[A-Za-z_$][\w$]*$/.test(key) ? key : JSON.stringify(key);
+}
+
+function serialize(value, depth, useLinkPreset) {
+	const pad = "\t".repeat(depth);
+	const padInner = "\t".repeat(depth + 1);
+
+	if (Array.isArray(value)) {
+		if (value.length === 0) return "[]";
+		const items = value.map((item) => {
+			if (useLinkPreset && typeof item === "number" && LINK_PRESET_NAMES.has(item)) {
+				return `${padInner}LinkPreset.${LINK_PRESET_NAMES.get(item)}`;
+			}
+			return `${padInner}${serialize(item, depth + 1, useLinkPreset)}`;
+		});
+		return `[\n${items.join(",\n")},\n${pad}]`;
+	}
+
+	if (isPlainObject(value)) {
+		const keys = Object.keys(value);
+		if (keys.length === 0) return "{}";
+		const entries = keys.map(
+			(key) =>
+				`${padInner}${formatKey(key)}: ${serialize(value[key], depth + 1, useLinkPreset)}`,
+		);
+		return `{\n${entries.join(",\n")},\n${pad}}`;
+	}
+
+	return JSON.stringify(value);
+}
+
+function renderFile(exportName, typeName, override) {
+	const usesLinkPreset = exportName === "navBarConfig";
+	const typeImport = TYPE_IN_CONFIG_FILE.has(typeName)
+		? `import type { DeepPartial } from "../../types/config";\nimport type { ${typeName} } from "../markdownConfig";`
+		: `import type { DeepPartial, ${typeName} } from "../../types/config";`;
+
+	const valueImport = usesLinkPreset
+		? `import { LinkPreset } from "../../types/config";\n`
+		: "";
+
+	return `${valueImport}${typeImport}
+
+export default ${serialize(override, 0, usesLinkPreset)} satisfies DeepPartial<${typeName}>;
+`;
+}
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const baseRef = resolveBaseRef(args.ref);
+	const baseHash = git(["rev-parse", "--short", baseRef]).trim();
+
+	console.log(`上游基准：${baseRef} (${baseHash})`);
+	console.log(`导出目录：${path.relative(rootDir, args.out) || "."}\n`);
+
+	const baseDir = materializeBaseTree(baseRef);
+	const written = [];
+	const identical = [];
+	const problems = [];
+
+	try {
+		for (const [file, exportName, typeName] of CONFIGS) {
+			const baseFile = path.join(baseDir, "src/config", `${file}.ts`);
+			if (!fs.existsSync(baseFile)) {
+				problems.push(`${exportName}：上游基准里没有 src/config/${file}.ts，跳过`);
+				continue;
+			}
+
+			const base = (await import(pathToUrl(baseFile)))[exportName];
+			const mine = (await import(pathToUrl(path.join(rootDir, "src/config", `${file}.ts`))))[exportName];
+
+			const override = minimalDiff(base, mine);
+			if (override === undefined) {
+				identical.push(exportName);
+				continue;
+			}
+
+			// 自检：导出的覆盖必须能还原出当前配置
+			if (!isDeepStrictEqual(deepMerge(base, override), mine)) {
+				const removed = findRemovedPaths(base, mine);
+				problems.push(
+					`${exportName}：覆盖无法还原当前配置${removed.length ? `，深合并表达不了这些被删掉的键：${removed.join("、")}` : ""}`,
+				);
+				continue;
+			}
+
+			fs.mkdirSync(args.out, { recursive: true });
+			fs.writeFileSync(
+				path.join(args.out, `${exportName}.ts`),
+				renderFile(exportName, typeName, override),
+			);
+			written.push([exportName, Object.keys(override).length]);
+		}
+	} finally {
+		fs.rmSync(baseDir, { recursive: true, force: true });
+	}
+
+	for (const [name, count] of written) {
+		console.log(`  已导出 ${name}.ts（${count} 个顶层键）`);
+	}
+	if (identical.length) {
+		console.log(`\n与上游一致、无需覆盖：${identical.join("、")}`);
+	}
+	if (problems.length) {
+		console.log("\n需要手工处理：");
+		for (const problem of problems) console.log(`  ✘ ${problem}`);
+	}
+
+	if (!written.length) {
+		console.log("\n当前配置与上游完全一致，没有需要导出的内容。");
+		return;
+	}
+
+	const outRel = path.relative(rootDir, args.out) || ".";
+	console.log(`\n共导出 ${written.length} 个覆盖文件到 ${outRel}/`);
+	console.log("\n接下来：");
+	console.log(`  1. 复制到内容仓库：cp ${outRel}/*.ts <内容仓库>/overrides/`);
+	console.log("  2. 把 src/config/ 还原成上游原版：");
+	console.log(`     git checkout ${baseRef} -- src/config/`);
+	console.log("  3. 同步并校验：pnpm sync-content && pnpm type-check && pnpm build");
+	console.log("\n详见 docs/CONTENT_SEPARATION.md 的「配置覆盖」章节。");
+
+	if (problems.length) process.exitCode = 1;
+}
+
+function pathToUrl(filePath) {
+	return `file:///${filePath.split(path.sep).join("/")}`;
+}
+
+main().catch((error) => {
+	console.error("✘ 导出失败：", error.message);
+	process.exit(1);
+});

--- a/scripts/read-site-config.mjs
+++ b/scripts/read-site-config.mjs
@@ -61,7 +61,7 @@ export function extractBlock(content, blockKey) {
  * 在若干份配置文本里按顺序查找 blockKey 块内的字段，返回第一个命中的捕获组。
  *
  * 覆盖文件里存在该块但没写这个字段时，继续往后一份文本找，而不是就地返回
- * 空值——这正是「只覆盖 vmid、coverMirror 仍取默认」能生效的原因。
+ * 空值，保证未覆盖的字段回退到默认配置。
  */
 export function matchInBlock(sources, blockKey, pattern) {
 	for (const content of sources) {

--- a/scripts/read-site-config.mjs
+++ b/scripts/read-site-config.mjs
@@ -1,0 +1,44 @@
+/**
+ * 站点配置取值助手（供 Node 脚本使用）
+ *
+ * 这些脚本直接由 node 运行，无法 import TypeScript 配置，沿用既有的正则读取
+ * 方式。src/config/overrides/siteConfig.ts 由 sync-content 从内容仓库同步而来，
+ * 存在时优先命中，读不到再回退 src/config/siteConfig.ts 里的上游默认值。
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+);
+
+const SOURCE_PATHS = [
+	path.join(rootDir, "src/config/overrides/siteConfig.ts"),
+	path.join(rootDir, "src/config/siteConfig.ts"),
+];
+
+let cachedSources = null;
+
+function readSources() {
+	if (!cachedSources) {
+		cachedSources = SOURCE_PATHS.filter((source) => fs.existsSync(source)).map(
+			(source) => fs.readFileSync(source, "utf-8"),
+		);
+	}
+	return cachedSources;
+}
+
+/**
+ * 按「覆盖 → 默认」的顺序返回第一个命中的捕获组，都没命中返回 null。
+ */
+export function matchSiteConfig(pattern) {
+	for (const content of readSources()) {
+		const match = content.match(pattern);
+		if (match) {
+			return match[1];
+		}
+	}
+	return null;
+}

--- a/scripts/read-site-config.mjs
+++ b/scripts/read-site-config.mjs
@@ -4,6 +4,10 @@
  * 这些脚本直接由 node 运行，无法 import TypeScript 配置，沿用既有的正则读取
  * 方式。src/config/overrides/siteConfig.ts 由 sync-content 从内容仓库同步而来，
  * 存在时优先命中，读不到再回退 src/config/siteConfig.ts 里的上游默认值。
+ *
+ * 取值一律限定在指定的顶层配置块内。覆盖文件是部分配置且键序任意，如果沿用
+ * 「块名后面第一个字段」的松散匹配，`anime: {}` 后面的 `font: { mode: ... }`
+ * 会被误读成番剧模式。这里用花括号配平把搜索范围钉死在块内。
  */
 import fs from "node:fs";
 import path from "node:path";
@@ -31,14 +35,51 @@ function readSources() {
 }
 
 /**
- * 按「覆盖 → 默认」的顺序返回第一个命中的捕获组，都没命中返回 null。
+ * 截取 `blockKey: { ... }` 的块内文本，块不存在时返回 null。
  */
-export function matchSiteConfig(pattern) {
-	for (const content of readSources()) {
-		const match = content.match(pattern);
+export function extractBlock(content, blockKey) {
+	const opener = content.match(new RegExp(`\\b${blockKey}\\s*:\\s*\\{`));
+	if (!opener) {
+		return null;
+	}
+
+	let index = opener.index + opener[0].length;
+	let depth = 1;
+	const start = index;
+
+	while (index < content.length && depth > 0) {
+		const char = content[index];
+		if (char === "{") depth++;
+		else if (char === "}") depth--;
+		index++;
+	}
+
+	return depth === 0 ? content.slice(start, index - 1) : null;
+}
+
+/**
+ * 在若干份配置文本里按顺序查找 blockKey 块内的字段，返回第一个命中的捕获组。
+ *
+ * 覆盖文件里存在该块但没写这个字段时，继续往后一份文本找，而不是就地返回
+ * 空值——这正是「只覆盖 vmid、coverMirror 仍取默认」能生效的原因。
+ */
+export function matchInBlock(sources, blockKey, pattern) {
+	for (const content of sources) {
+		const block = extractBlock(content, blockKey);
+		if (block === null) {
+			continue;
+		}
+		const match = block.match(pattern);
 		if (match) {
 			return match[1];
 		}
 	}
 	return null;
+}
+
+/**
+ * 按「覆盖 → 默认」的顺序读取 siteConfig 某个块内的字段，都没命中返回 null。
+ */
+export function matchSiteConfig(blockKey, pattern) {
+	return matchInBlock(readSources(), blockKey, pattern);
 }

--- a/scripts/sync-content.js
+++ b/scripts/sync-content.js
@@ -98,6 +98,7 @@ const contentMappings = [
 	{ src: "spec", dest: "src/content/spec" },
 	{ src: "data", dest: "src/data" },
 	{ src: "images", dest: "public/images" },
+	{ src: "overrides", dest: "src/config/overrides" },
 ];
 
 for (const mapping of contentMappings) {

--- a/scripts/sync-content.js
+++ b/scripts/sync-content.js
@@ -98,7 +98,9 @@ const contentMappings = [
 	{ src: "spec", dest: "src/content/spec" },
 	{ src: "data", dest: "src/data" },
 	{ src: "images", dest: "public/images" },
-	{ src: "overrides", dest: "src/config/overrides" },
+	// 覆盖文件是带相对导入的 TS 模块，符号链接会被 Vite 解析到内容仓库真实
+	// 路径导致找不到 types/config，因此复制进代码仓库而不是建链接
+	{ src: "overrides", dest: "src/config/overrides", copy: true },
 ];
 
 for (const mapping of contentMappings) {
@@ -106,7 +108,34 @@ for (const mapping of contentMappings) {
 	const destPath = path.join(rootDir, mapping.dest);
 
 	if (!fs.existsSync(srcPath)) {
+		// 内容仓库删掉 overrides/ 后清掉上次的副本，避免旧配置继续生效
+		if (mapping.copy) {
+			const stat = fs.lstatSync(destPath, { throwIfNoEntry: false });
+			if (stat) {
+				if (stat.isSymbolicLink()) {
+					fs.unlinkSync(destPath);
+				} else {
+					fs.rmSync(destPath, { recursive: true, force: true });
+				}
+				console.log(`已清理失效的配置覆盖：${mapping.dest}`);
+			}
+		}
 		console.log(`跳过不存在的源目录：${mapping.src}`);
+		continue;
+	}
+
+	// 覆盖目录由本脚本复制维护，直接删除重建，不走备份逻辑
+	if (mapping.copy) {
+		const stat = fs.lstatSync(destPath, { throwIfNoEntry: false });
+		if (stat) {
+			if (stat.isSymbolicLink()) {
+				fs.unlinkSync(destPath);
+			} else {
+				fs.rmSync(destPath, { recursive: true, force: true });
+			}
+		}
+		copyRecursive(srcPath, destPath);
+		console.log(`已复制配置覆盖：${mapping.src} -> ${mapping.dest}`);
 		continue;
 	}
 

--- a/scripts/update-anime.mjs
+++ b/scripts/update-anime.mjs
@@ -4,9 +4,7 @@ import { fileURLToPath } from "url";
 import { matchSiteConfig } from "./read-site-config.mjs";
 
 function getAnimeModeFromConfig() {
-	return (
-		matchSiteConfig(/anime:\s*\{[\s\S]*?mode:\s*["']([^"']+)["']/) || "bangumi"
-	);
+	return matchSiteConfig("anime", /mode:\s*["']([^"']+)["']/) || "bangumi";
 }
 
 function runScript(scriptPath) {

--- a/scripts/update-anime.mjs
+++ b/scripts/update-anime.mjs
@@ -1,27 +1,12 @@
 import { spawn } from "child_process";
-import fs from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
+import { matchSiteConfig } from "./read-site-config.mjs";
 
-const CONFIG_PATH = path.join(
-	path.dirname(fileURLToPath(import.meta.url)),
-	"../src/config/siteConfig.ts",
-);
-
-async function getAnimeModeFromConfig() {
-	try {
-		const configContent = await fs.readFile(CONFIG_PATH, "utf-8");
-		const match = configContent.match(
-			/anime:\s*\{[\s\S]*?mode:\s*["']([^"']+)["']/,
-		);
-
-		if (match && match[1]) {
-			return match[1];
-		}
-		return "bangumi";
-	} catch (error) {
-		return "bangumi";
-	}
+function getAnimeModeFromConfig() {
+	return (
+		matchSiteConfig(/anime:\s*\{[\s\S]*?mode:\s*["']([^"']+)["']/) || "bangumi"
+	);
 }
 
 function runScript(scriptPath) {
@@ -46,7 +31,7 @@ function runScript(scriptPath) {
 }
 
 async function main() {
-	const mode = await getAnimeModeFromConfig();
+	const mode = getAnimeModeFromConfig();
 	const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
 
 	if (mode === "bilibili") {

--- a/scripts/update-bangumi.mjs
+++ b/scripts/update-bangumi.mjs
@@ -1,59 +1,37 @@
 import fs from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
+import { matchSiteConfig } from "./read-site-config.mjs";
 
 const API_BASE = "https://api.bgm.tv";
-const CONFIG_PATH = path.join(
-	path.dirname(fileURLToPath(import.meta.url)),
-	"../src/config/siteConfig.ts",
-);
 const OUTPUT_FILE = path.join(
 	path.dirname(fileURLToPath(import.meta.url)),
 	"../src/data/bangumi-data.json",
 );
 
-async function getUserIdFromConfig() {
-	try {
-		const configContent = await fs.readFile(CONFIG_PATH, "utf-8");
-		const match = configContent.match(
-			/bangumi:\s*\{[\s\S]*?userId:\s*["']([^"']+)["']/,
-		);
+function getUserIdFromConfig() {
+	const userId = matchSiteConfig(
+		/bangumi:\s*\{[\s\S]*?userId:\s*["']([^"']+)["']/,
+	);
 
-		if (match && match[1]) {
-			const userId = match[1];
-			if (
-				userId === "your-bangumi-id" ||
-				userId === "your-user-id" ||
-				!userId
-			) {
-				console.warn(
-					"Warning: userId in src/config/siteConfig.ts appears to be a default value.",
-				);
-				return userId;
-			}
-			return userId;
-		}
-		throw new Error("Could not find bangumi.userId in config/siteConfig.ts");
-	} catch (error) {
+	if (!userId) {
 		console.error("✘ Failed to read Bangumi ID from config/siteConfig.ts");
-		throw error;
+		throw new Error("Could not find bangumi.userId in config/siteConfig.ts");
 	}
+
+	if (userId === "your-bangumi-id" || userId === "your-user-id") {
+		console.warn(
+			"Warning: userId in src/config/siteConfig.ts appears to be a default value.",
+		);
+	}
+
+	return userId;
 }
 
-async function getAnimeModeFromConfig() {
-	try {
-		const configContent = await fs.readFile(CONFIG_PATH, "utf-8");
-		const match = configContent.match(
-			/anime:\s*\{[\s\S]*?mode:\s*["']([^"']+)["']/,
-		);
-
-		if (match && match[1]) {
-			return match[1];
-		}
-		return "bangumi";
-	} catch (error) {
-		return "bangumi";
-	}
+function getAnimeModeFromConfig() {
+	return (
+		matchSiteConfig(/anime:\s*\{[\s\S]*?mode:\s*["']([^"']+)["']/) || "bangumi"
+	);
 }
 
 // 模拟延迟防止 API 限制
@@ -203,7 +181,7 @@ async function processData(items, status) {
 async function main() {
 	console.log("Initializing Bangumi data update script...");
 
-	const animeMode = await getAnimeModeFromConfig();
+	const animeMode = getAnimeModeFromConfig();
 	if (animeMode !== "bangumi") {
 		console.log(
 			`Detected current anime mode is "${animeMode}", skipping Bangumi data update.`,
@@ -211,7 +189,7 @@ async function main() {
 		return;
 	}
 
-	const USER_ID = await getUserIdFromConfig();
+	const USER_ID = getUserIdFromConfig();
 	console.log(`Read User ID: ${USER_ID}`);
 
 	const collections = [

--- a/scripts/update-bangumi.mjs
+++ b/scripts/update-bangumi.mjs
@@ -10,9 +10,7 @@ const OUTPUT_FILE = path.join(
 );
 
 function getUserIdFromConfig() {
-	const userId = matchSiteConfig(
-		/bangumi:\s*\{[\s\S]*?userId:\s*["']([^"']+)["']/,
-	);
+	const userId = matchSiteConfig("bangumi", /userId:\s*["']([^"']+)["']/);
 
 	if (!userId) {
 		console.error("✘ Failed to read Bangumi ID from config/siteConfig.ts");
@@ -29,9 +27,7 @@ function getUserIdFromConfig() {
 }
 
 function getAnimeModeFromConfig() {
-	return (
-		matchSiteConfig(/anime:\s*\{[\s\S]*?mode:\s*["']([^"']+)["']/) || "bangumi"
-	);
+	return matchSiteConfig("anime", /mode:\s*["']([^"']+)["']/) || "bangumi";
 }
 
 // 模拟延迟防止 API 限制

--- a/scripts/update-bilibili.mjs
+++ b/scripts/update-bilibili.mjs
@@ -38,9 +38,7 @@ async function withRetry(apiCall, retries = 3) {
 }
 
 function getUserIdFromConfig() {
-	const vmid = matchSiteConfig(
-		/bilibili:\s*\{[\s\S]*?vmid:\s*["']([^"']+)["']/,
-	);
+	const vmid = matchSiteConfig("bilibili", /vmid:\s*["']([^"']+)["']/);
 
 	if (vmid === null) {
 		console.error("✘ Failed to read Bilibili vmid from config/siteConfig.ts");
@@ -60,17 +58,15 @@ async function getSessdataFromConfig() {
 }
 
 function getCoverMirrorFromConfig() {
-	return matchSiteConfig(/coverMirror:\s*["']([^"']*)["']/) ?? "";
+	return matchSiteConfig("bilibili", /coverMirror:\s*["']([^"']*)["']/) ?? "";
 }
 
 function getUseWebpFromConfig() {
-	return matchSiteConfig(/useWebp:\s*(true|false)/) !== "false";
+	return matchSiteConfig("bilibili", /useWebp:\s*(true|false)/) !== "false";
 }
 
 function getAnimeModeFromConfig() {
-	return (
-		matchSiteConfig(/anime:\s*\{[\s\S]*?mode:\s*["']([^"']+)["']/) || "bangumi"
-	);
+	return matchSiteConfig("anime", /mode:\s*["']([^"']+)["']/) || "bangumi";
 }
 
 async function getDataPage(vmid, status, typeNum = 1) {

--- a/scripts/update-bilibili.mjs
+++ b/scripts/update-bilibili.mjs
@@ -3,15 +3,12 @@ import path from "path";
 import { fileURLToPath } from "url";
 import axios from "axios";
 import { loadEnv } from "./load-env.js";
+import { matchSiteConfig } from "./read-site-config.mjs";
 
 loadEnv();
 
 const API_BASE = "https://api.bilibili.com/x/space/bangumi/follow/list";
 const PAGE_SIZE = 30;
-const CONFIG_PATH = path.join(
-	path.dirname(fileURLToPath(import.meta.url)),
-	"../src/config/siteConfig.ts",
-);
 const OUTPUT_FILE = path.join(
 	path.dirname(fileURLToPath(import.meta.url)),
 	"../src/data/bilibili-data.json",
@@ -40,65 +37,40 @@ async function withRetry(apiCall, retries = 3) {
 	}
 }
 
-async function getUserIdFromConfig() {
-	try {
-		const configContent = await fs.readFile(CONFIG_PATH, "utf-8");
-		const match = configContent.match(
-			/bilibili:\s*\{[\s\S]*?vmid:\s*["']([^"']+)["']/,
-		);
+function getUserIdFromConfig() {
+	const vmid = matchSiteConfig(
+		/bilibili:\s*\{[\s\S]*?vmid:\s*["']([^"']+)["']/,
+	);
 
-		if (match && match[1]) {
-			const vmid = match[1];
-			if (!vmid || vmid.trim() === "") {
-				console.warn("Warning: vmid in src/config/siteConfig.ts is empty.");
-				return null;
-			}
-			return vmid;
-		}
-		throw new Error("Could not find bilibili.vmid in config/siteConfig.ts");
-	} catch (error) {
+	if (vmid === null) {
 		console.error("✘ Failed to read Bilibili vmid from config/siteConfig.ts");
-		throw error;
+		throw new Error("Could not find bilibili.vmid in config/siteConfig.ts");
 	}
+
+	if (vmid.trim() === "") {
+		console.warn("Warning: vmid in src/config/siteConfig.ts is empty.");
+		return null;
+	}
+
+	return vmid;
 }
 
 async function getSessdataFromConfig() {
 	return process.env.BILI_SESSDATA || "";
 }
 
-async function getCoverMirrorFromConfig() {
-	try {
-		const configContent = await fs.readFile(CONFIG_PATH, "utf-8");
-		const match = configContent.match(/coverMirror:\s*["']([^"']*)["']/);
-		return match ? match[1] : "";
-	} catch {
-		return "";
-	}
+function getCoverMirrorFromConfig() {
+	return matchSiteConfig(/coverMirror:\s*["']([^"']*)["']/) ?? "";
 }
 
-async function getUseWebpFromConfig() {
-	try {
-		const configContent = await fs.readFile(CONFIG_PATH, "utf-8");
-		return !configContent.match(/useWebp:\s*false/);
-	} catch {
-		return true;
-	}
+function getUseWebpFromConfig() {
+	return matchSiteConfig(/useWebp:\s*(true|false)/) !== "false";
 }
 
-async function getAnimeModeFromConfig() {
-	try {
-		const configContent = await fs.readFile(CONFIG_PATH, "utf-8");
-		const match = configContent.match(
-			/anime:\s*\{[\s\S]*?mode:\s*["']([^"']+)["']/,
-		);
-
-		if (match && match[1]) {
-			return match[1];
-		}
-		return "bangumi";
-	} catch (error) {
-		return "bangumi";
-	}
+function getAnimeModeFromConfig() {
+	return (
+		matchSiteConfig(/anime:\s*\{[\s\S]*?mode:\s*["']([^"']+)["']/) || "bangumi"
+	);
 }
 
 async function getDataPage(vmid, status, typeNum = 1) {
@@ -317,7 +289,7 @@ async function processData(
 async function main() {
 	console.log("Initializing Bilibili data update script...");
 
-	const animeMode = await getAnimeModeFromConfig();
+	const animeMode = getAnimeModeFromConfig();
 	if (animeMode !== "bilibili") {
 		console.log(
 			`Detected current anime mode is "${animeMode}", skipping Bilibili data update.`,
@@ -325,7 +297,7 @@ async function main() {
 		return;
 	}
 
-	const VMID = await getUserIdFromConfig();
+	const VMID = getUserIdFromConfig();
 	if (!VMID) {
 		console.error(
 			"✘ Bilibili vmid is not set. Please set it in src/config/siteConfig.ts",
@@ -335,8 +307,8 @@ async function main() {
 	console.log(`Read User ID: ${VMID}`);
 
 	const SESSDATA = await getSessdataFromConfig();
-	const coverMirror = await getCoverMirrorFromConfig();
-	const useWebp = await getUseWebpFromConfig();
+	const coverMirror = getCoverMirrorFromConfig();
+	const useWebp = getUseWebpFromConfig();
 
 	// 获取三种状态的数据 (1=想看, 2=在看, 3=已看)
 	console.log("\nFetching Bilibili bangumi data...");

--- a/src/config/deepMerge.ts
+++ b/src/config/deepMerge.ts
@@ -1,0 +1,41 @@
+/**
+ * 配置覆盖的合并语义
+ *
+ * 供 src/config/index.ts 把 src/config/overrides/ 下的部分覆盖合并进上游默认
+ * 配置。这里刻意不引入任何 Vite 专有语法（如 import.meta.glob），以便直接用
+ * node --experimental-strip-types 做单元测试。
+ *
+ * 合并规则：
+ * - 双方都是普通对象 → 递归合并，覆盖值只影响写到的字段；
+ * - 其余情况（数组、标量、null）→ 覆盖值整体替换，不做拼接；
+ * - 覆盖值中显式写成 undefined 的键 → 跳过，保留默认值。
+ *
+ * 合并不会修改 base，默认配置对象始终保持原样。
+ */
+export function deepMerge<T>(base: T, override: unknown): T {
+	if (override === undefined) {
+		return base;
+	}
+
+	if (!isPlainObject(base) || !isPlainObject(override)) {
+		return override as T;
+	}
+
+	const merged: Record<string, unknown> = { ...base };
+	for (const [key, value] of Object.entries(override)) {
+		if (value === undefined) {
+			continue;
+		}
+		merged[key] = deepMerge(merged[key], value);
+	}
+
+	return merged as T;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	if (typeof value !== "object" || value === null) {
+		return false;
+	}
+	const proto = Object.getPrototypeOf(value);
+	return proto === Object.prototype || proto === null;
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,7 +8,7 @@
  * 导出名称                      │ 文件                       │ 说明
  * ─────────────────────────────┼────────────────────────────┼──────────────────────────────
  * siteConfig                    │ siteConfig.ts              │ 站点核心配置（标题、语言、主题色、横幅、字体、特色页面开关等）
- * SITE_LANG                     │ siteConfig.ts              │ 站点语言常量（从 siteConfig 中导出）
+ * SITE_LANG                     │ (派生)                     │ 站点语言常量（取合并后的 siteConfig.lang）
  * fullscreenWallpaperConfig     │ backgroundWallpaper.ts     │ 全屏壁纸模式配置（图片源、轮播、透明度、模糊）
  * navBarConfig                  │ navBarConfig.ts            │ 导航栏菜单配置（链接、多级下拉菜单）
  * profileConfig                 │ profileConfig.ts           │ 个人资料（头像、昵称、简介、社交链接）
@@ -26,6 +26,18 @@
  * relatedPostsConfig            │ relatedPostsConfig.ts      │ 相关文章推荐（开关、数量）
  * randomPostsConfig             │ randomPostsConfig.ts       │ 随机文章推荐（开关、数量）
  * widgetConfigs                 │ (聚合)                     │ 侧边栏 Widget 配置聚合对象
+ *
+ * ══════════════════════════════════════════════════════════════
+ * 配置覆盖（可选）
+ * ══════════════════════════════════════════════════════════════
+ *
+ * 各配置文件保存上游默认值，本文件在导出前把 src/config/overrides/ 下的同名
+ * 覆盖文件深合并进来：
+ *
+ *   最终配置 = deepMerge(上游默认配置, overrides/<导出名>.ts 的 default 导出)
+ *
+ * 覆盖目录由 sync-content 从内容仓库的 overrides/ 同步，不存在时所有配置等同
+ * 于上游默认值。详见 docs/CONTENT_SEPARATION.md。
  *
  * ══════════════════════════════════════════════════════════════
  * 类型定义
@@ -48,50 +60,99 @@
  *   import { siteConfig } from "src/config";
  *
  * 以上三种方式都会自动解析到此 index.ts 文件。
+ * 请始终从本入口读取配置，直接 import 某个配置文件会绕过覆盖合并。
  */
 
-export { announcementConfig } from "./announcementConfig";
+import { announcementConfig as announcementDefaults } from "./announcementConfig";
+import { fullscreenWallpaperConfig as fullscreenWallpaperDefaults } from "./backgroundWallpaper";
+import { commentConfig as commentDefaults } from "./commentConfig";
+import { sakuraConfig as sakuraDefaults } from "./effectsConfig";
+import { expressiveCodeConfig as expressiveCodeDefaults } from "./expressiveCodeConfig";
+import { footerConfig as footerDefaults } from "./footerConfig";
+import { licenseConfig as licenseDefaults } from "./licenseConfig";
+import { markdownConfig as markdownDefaults } from "./markdownConfig";
+import { musicPlayerConfig as musicPlayerDefaults } from "./musicConfig";
+import { navBarConfig as navBarDefaults } from "./navBarConfig";
+import { withOverride } from "./overrideLoader";
+import { permalinkConfig as permalinkDefaults } from "./permalinkConfig";
+import { pioConfig as pioDefaults } from "./pioConfig";
+import { profileConfig as profileDefaults } from "./profileConfig";
+import { randomPostsConfig as randomPostsDefaults } from "./randomPostsConfig";
+import { relatedPostsConfig as relatedPostsDefaults } from "./relatedPostsConfig";
+import { shareConfig as shareDefaults } from "./shareConfig";
+import { sidebarLayoutConfig as sidebarLayoutDefaults } from "./sidebarConfig";
+import { siteConfig as siteDefaults } from "./siteConfig";
+
+// ─── 站点核心 ───────────────────────────────────────────────
+export const siteConfig = withOverride("siteConfig", siteDefaults);
+
+// SITE_LANG 从合并后的站点配置派生，覆盖 siteConfig.lang 后会一并生效。
+// 注意：commentConfig.ts 在模块顶层引用了 siteConfig.ts 里的同名常量填充评论
+// 语言，若覆盖了 siteConfig.lang，需要同时覆盖 commentConfig 的对应字段。
+export const SITE_LANG = siteConfig.lang;
 
 // ─── 外观与壁纸 ─────────────────────────────────────────────
-export { fullscreenWallpaperConfig } from "./backgroundWallpaper";
+export const fullscreenWallpaperConfig = withOverride(
+	"fullscreenWallpaperConfig",
+	fullscreenWallpaperDefaults,
+);
+
 // ─── 互动功能 ───────────────────────────────────────────────
-export { commentConfig } from "./commentConfig";
-export { sakuraConfig } from "./effectsConfig";
+export const commentConfig = withOverride("commentConfig", commentDefaults);
+export const sakuraConfig = withOverride("sakuraConfig", sakuraDefaults);
+
 // ─── 代码块 ─────────────────────────────────────────────────
-export { expressiveCodeConfig } from "./expressiveCodeConfig";
-export { footerConfig } from "./footerConfig";
+export const expressiveCodeConfig = withOverride(
+	"expressiveCodeConfig",
+	expressiveCodeDefaults,
+);
+
+export const footerConfig = withOverride("footerConfig", footerDefaults);
+
 // ─── 内容与版权 ─────────────────────────────────────────────
-export { licenseConfig } from "./licenseConfig";
-export { markdownConfig } from "./markdownConfig";
+export const licenseConfig = withOverride("licenseConfig", licenseDefaults);
+export const markdownConfig = withOverride("markdownConfig", markdownDefaults);
+
 // ─── 多媒体 ─────────────────────────────────────────────────
-export { musicPlayerConfig } from "./musicConfig";
+export const musicPlayerConfig = withOverride(
+	"musicPlayerConfig",
+	musicPlayerDefaults,
+);
+
 // ─── 导航栏 ─────────────────────────────────────────────────
-export { navBarConfig } from "./navBarConfig";
-export { permalinkConfig } from "./permalinkConfig";
-export { pioConfig } from "./pioConfig";
+export const navBarConfig = withOverride("navBarConfig", navBarDefaults);
+export const permalinkConfig = withOverride(
+	"permalinkConfig",
+	permalinkDefaults,
+);
+export const pioConfig = withOverride("pioConfig", pioDefaults);
+
 // ─── 个人资料 ───────────────────────────────────────────────
-export { profileConfig } from "./profileConfig";
-export { randomPostsConfig } from "./randomPostsConfig";
+export const profileConfig = withOverride("profileConfig", profileDefaults);
+export const randomPostsConfig = withOverride(
+	"randomPostsConfig",
+	randomPostsDefaults,
+);
+
 // ─── 文章推荐 ───────────────────────────────────────────────
-export { relatedPostsConfig } from "./relatedPostsConfig";
-export { shareConfig } from "./shareConfig";
+export const relatedPostsConfig = withOverride(
+	"relatedPostsConfig",
+	relatedPostsDefaults,
+);
+export const shareConfig = withOverride("shareConfig", shareDefaults);
+
 // ─── 布局 ───────────────────────────────────────────────────
-export { sidebarLayoutConfig } from "./sidebarConfig";
-// ─── 站点核心 ───────────────────────────────────────────────
-export { SITE_LANG, siteConfig } from "./siteConfig";
+export const sidebarLayoutConfig = withOverride(
+	"sidebarLayoutConfig",
+	sidebarLayoutDefaults,
+);
 
-import { announcementConfig } from "./announcementConfig";
-import { fullscreenWallpaperConfig } from "./backgroundWallpaper";
-import { sakuraConfig } from "./effectsConfig";
-import { musicPlayerConfig } from "./musicConfig";
-import { pioConfig } from "./pioConfig";
+export const announcementConfig = withOverride(
+	"announcementConfig",
+	announcementDefaults,
+);
+
 // ─── Widget 配置聚合（供 Swup 等运行时使用）────────────────
-import { profileConfig } from "./profileConfig";
-import { randomPostsConfig } from "./randomPostsConfig";
-import { relatedPostsConfig } from "./relatedPostsConfig";
-import { shareConfig } from "./shareConfig";
-import { sidebarLayoutConfig } from "./sidebarConfig";
-
 export const widgetConfigs = {
 	profile: profileConfig,
 	announcement: announcementConfig,

--- a/src/config/overrideLoader.ts
+++ b/src/config/overrideLoader.ts
@@ -1,0 +1,74 @@
+/**
+ * 配置覆盖加载器
+ *
+ * 从 src/config/overrides/ 读取用户的部分配置覆盖，合并进上游默认配置。
+ * 该目录由 sync-content 从内容仓库的 overrides/ 同步而来，不随代码仓库提交；
+ * 目录缺失时 import.meta.glob 返回空对象，所有配置退回上游默认值。
+ *
+ * 约定：覆盖文件名 = 被覆盖的导出常量名。例如 overrides/sakuraConfig.ts 覆盖
+ * sakuraConfig（注意上游文件名是 effectsConfig.ts）。文件名拼错会在构建期报错，
+ * 而不是静默失效。
+ */
+import { deepMerge } from "./deepMerge";
+
+const OVERRIDABLE_CONFIGS = [
+	"announcementConfig",
+	"commentConfig",
+	"expressiveCodeConfig",
+	"footerConfig",
+	"fullscreenWallpaperConfig",
+	"licenseConfig",
+	"markdownConfig",
+	"musicPlayerConfig",
+	"navBarConfig",
+	"permalinkConfig",
+	"pioConfig",
+	"profileConfig",
+	"randomPostsConfig",
+	"relatedPostsConfig",
+	"sakuraConfig",
+	"shareConfig",
+	"sidebarLayoutConfig",
+	"siteConfig",
+] as const;
+
+export type OverridableConfigName = (typeof OVERRIDABLE_CONFIGS)[number];
+
+const overrideModules = import.meta.glob<{ default?: unknown }>(
+	"./overrides/*.ts",
+	{ eager: true },
+);
+
+const overrides = collectOverrides();
+
+function collectOverrides(): Map<string, unknown> {
+	const allowed = new Set<string>(OVERRIDABLE_CONFIGS);
+	const collected = new Map<string, unknown>();
+
+	for (const [modulePath, module] of Object.entries(overrideModules)) {
+		const name = modulePath.replace(/^.*\//, "").replace(/\.ts$/, "");
+
+		if (!allowed.has(name)) {
+			throw new Error(
+				`Unknown config override "${modulePath}". The file name must match one of the exported config names: ${OVERRIDABLE_CONFIGS.join(", ")}`,
+			);
+		}
+
+		if (module?.default === undefined) {
+			throw new Error(
+				`Config override "${modulePath}" has no default export. Expected: export default { ... } satisfies DeepPartial<${name === "siteConfig" ? "SiteConfig" : "..."}>`,
+			);
+		}
+
+		collected.set(name, module.default);
+	}
+
+	return collected;
+}
+
+/**
+ * 把同名覆盖合并进默认配置。没有对应覆盖文件时原样返回默认配置。
+ */
+export function withOverride<T>(name: OverridableConfigName, base: T): T {
+	return deepMerge(base, overrides.get(name));
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -591,3 +591,16 @@ export interface ThirdPartyAnalyticsConfig {
 	enable: boolean; // 是否启用第三方统计（Microsoft Clarity），默认关闭
 	clarityId?: string; // Clarity 项目 ID
 }
+
+/**
+ * 递归可选类型，供 src/config/overrides/ 下的配置覆盖文件使用。
+ *
+ * `Partial<T>` 只把顶层键变成可选，无法表达「只改 themeColor.hue、其余取
+ * 默认值」这类部分覆盖；数组分支直接短路，避免 `string[]` 退化成
+ * `(string | undefined)[]`（数组在合并时本就整体替换）。
+ */
+export type DeepPartial<T> = T extends readonly unknown[]
+	? T
+	: T extends object
+		? { [K in keyof T]?: DeepPartial<T[K]> }
+		: T;

--- a/src/utils/image-utils.ts
+++ b/src/utils/image-utils.ts
@@ -1,4 +1,4 @@
-import { siteConfig } from "../config/siteConfig";
+import { siteConfig } from "../config";
 import type { ImageFormat } from "../types/config";
 import { matchesNoReferrerDomain } from "./image-referrer";
 

--- a/tests/config-overrides.test.ts
+++ b/tests/config-overrides.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { deepMerge } from "../src/config/deepMerge.ts";
+
+describe("config override merge", () => {
+	it("只覆盖写到的字段，其余取默认值", () => {
+		const base = {
+			themeColor: { hue: 240, fixed: false },
+			banner: { position: "center", carousel: { enable: true, interval: 3 } },
+		};
+
+		const merged = deepMerge(base, {
+			banner: { carousel: { interval: 8 } },
+		});
+
+		assert.deepEqual(merged, {
+			themeColor: { hue: 240, fixed: false },
+			banner: { position: "center", carousel: { enable: true, interval: 8 } },
+		});
+	});
+
+	it("数组整体替换而不是拼接", () => {
+		const base = { src: { desktop: ["1.webp", "2.webp", "3.webp"] } };
+
+		const merged = deepMerge(base, { src: { desktop: ["only.webp"] } });
+
+		assert.deepEqual(merged.src.desktop, ["only.webp"]);
+	});
+
+	it("跳过覆盖值中显式写成 undefined 的键", () => {
+		const merged = deepMerge({ title: "Mizuki" }, { title: undefined });
+
+		assert.equal(merged.title, "Mizuki");
+	});
+
+	it("覆盖值为 null 时按整体替换处理", () => {
+		const merged = deepMerge(
+			{ credit: { url: "https://example.com/" } },
+			{
+				credit: { url: null },
+			},
+		);
+
+		assert.equal(merged.credit.url, null);
+	});
+
+	it("覆盖缺失时原样返回默认配置", () => {
+		const base = { title: "Mizuki" };
+
+		assert.equal(deepMerge(base, undefined), base);
+	});
+
+	it("不修改默认配置对象", () => {
+		const base = { themeColor: { hue: 240, fixed: false } };
+
+		deepMerge(base, { themeColor: { hue: 30 } });
+
+		assert.equal(base.themeColor.hue, 240);
+	});
+
+	it("默认值里不存在的键会被补上", () => {
+		const merged = deepMerge<{ keywords?: string[] }>(
+			{},
+			{
+				keywords: ["blog"],
+			},
+		);
+
+		assert.deepEqual(merged.keywords, ["blog"]);
+	});
+});

--- a/tests/site-config-reader.test.ts
+++ b/tests/site-config-reader.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { extractBlock, matchInBlock } from "../scripts/read-site-config.mjs";
+
+// 上游默认配置的缩影：字段齐全，块顺序固定
+const DEFAULTS = `
+export const siteConfig: SiteConfig = {
+	navbarTitle: { mode: "text-icon", text: "MizukiUI" },
+	font: { mode: "custom" },
+	bangumi: { userId: "your-bangumi-id", fetchOnDev: false },
+	bilibili: { vmid: "", coverMirror: "", useWebp: true },
+	anime: { mode: "local" },
+};
+`;
+
+const MODE = /mode:\s*["']([^"']+)["']/;
+const VMID = /vmid:\s*["']([^"']*)["']/;
+const COVER_MIRROR = /coverMirror:\s*["']([^"']*)["']/;
+const USE_WEBP = /useWebp:\s*(true|false)/;
+
+describe("Node 脚本读取站点配置", () => {
+	it("没有覆盖文件时读上游默认值", () => {
+		assert.equal(matchInBlock([DEFAULTS], "anime", MODE), "local");
+		assert.equal(matchInBlock([DEFAULTS], "bilibili", USE_WEBP), "true");
+	});
+
+	it("覆盖文件优先于默认值", () => {
+		const override = `export default { anime: { mode: "bilibili" } };`;
+
+		assert.equal(matchInBlock([override, DEFAULTS], "anime", MODE), "bilibili");
+	});
+
+	it("覆盖块里缺少的字段继续回退到默认值", () => {
+		// 只覆盖 vmid，coverMirror / useWebp 仍应取上游默认
+		const override = `export default { bilibili: { vmid: "1129280784" } };`;
+		const sources = [override, DEFAULTS];
+
+		assert.equal(matchInBlock(sources, "bilibili", VMID), "1129280784");
+		assert.equal(matchInBlock(sources, "bilibili", COVER_MIRROR), "");
+		assert.equal(matchInBlock(sources, "bilibili", USE_WEBP), "true");
+	});
+
+	it("取值不会越过块边界串到相邻配置", () => {
+		// anime 块是空的，后面 font.mode 不能被当成番剧模式
+		const override = `export default {
+			anime: {},
+			font: { mode: "system" },
+		};`;
+
+		assert.equal(matchInBlock([override, DEFAULTS], "anime", MODE), "local");
+	});
+
+	it("覆盖文件里不存在的块直接跳过", () => {
+		const override = `export default { title: "我的站点" };`;
+
+		assert.equal(matchInBlock([override, DEFAULTS], "anime", MODE), "local");
+	});
+
+	it("所有来源都没有该块时返回 null，由调用方兜底", () => {
+		assert.equal(matchInBlock([DEFAULTS], "notAConfigBlock", MODE), null);
+	});
+
+	it("块内嵌套对象不会提前截断", () => {
+		const content = `{
+			banner: { src: { desktop: ["a"] }, position: "center" },
+			anime: { mode: "bangumi" },
+		}`;
+
+		const banner = extractBlock(content, "banner");
+		assert.match(banner, /position:\s*"center"/);
+		assert.equal(matchInBlock([content], "anime", MODE), "bangumi");
+	});
+
+	it("花括号不配平时视为没有该块", () => {
+		assert.equal(extractBlock(`anime: { mode: "local"`, "anime"), null);
+	});
+});


### PR DESCRIPTION
## 背景

Closes #549

Mizuki 已经有了很完善的**内容分离**（`ENABLE_CONTENT_SYNC` + `sync-content`），文章、页面数据、图片都可以放进独立仓库。但 `src/config/` 下的配置项仍然必须直接改代码仓库的源文件。

对于 fork 上游、定期跟进版本更新的用户，配置文件是**升级冲突的重灾区**：上游每次调整配置结构，都会和本地的个人值冲突，需要逐个人工解决。实测参照：一个真实的个人站点相对上游改动了 9 个配置文件、约 630 行，每次合并上游都要在这些文件上处理冲突。

本 PR 把配置也纳入同一套分离机制：**`src/config/*.ts` 保持上游原版，个人值放进内容仓库的 `overrides/`，构建时深合并。**

> ⚠️ **实验性功能，慎用**：该机制目前测试覆盖的场景有限，文档中已明确标注；采用前请备份现有配置，迁移后完整校验。

## 方案

```
内容仓库 overrides/  ──sync-content──>  代码仓库 src/config/overrides/
                                                    │
                     src/config/index.ts 在导出前深合并 ↓

              最终配置 = deepMerge(上游默认配置, 同名覆盖文件的 default 导出)
```

- 覆盖文件名 = 被覆盖的导出常量名（`overrides/siteConfig.ts` 覆盖 `siteConfig`），共 18 个合法名
- `src/config/overrides/` 已加入 `.gitignore`，不进入代码仓库提交历史
- **完全可选**：不创建 `overrides/` 时，`import.meta.glob` 返回空对象，所有配置等同于上游默认值，行为与现状逐字节一致

### 合并语义

| 情况 | 行为 |
| --- | --- |
| 双方都是普通对象 | 深合并，覆盖值只影响写到的字段 |
| 数组 | 整体替换，不拼接 |
| 标量、`null` | 整体替换 |
| 覆盖值里显式写 `undefined` 的键 | 跳过，保留默认值 |
| 没有对应覆盖文件 | 原样使用上游默认值 |

举例：默认 `banner.carousel` 是 `{ enable: true, interval: 3, switchable: true }`，覆盖里只写 `{ interval: 8 }`，结果是 `{ enable: true, interval: 8, switchable: true }`。

### 类型安全

覆盖文件用 `satisfies DeepPartial<XxxConfig>` 约束。这里必须是 `DeepPartial` 而不是 issue 里最初设想的 `Partial`——`Partial<T>` 只让**顶层**键可选，而 `SiteConfig` 的嵌套块字段大多必填（`themeColor` 的 `hue`/`fixed`、`banner.carousel` 的 `enable`/`interval`/`switchable`），写 `carousel: { interval: 8 }` 会直接编译报错，恰恰是部分覆盖最常见的写法。

`tsconfig.json` 的 `include: src/**/*` 已经覆盖同步目标目录，所以 `pnpm type-check` 会检查覆盖文件。三类错误都能在构建期拦住：

```
键名拼错   → TS2561  Object literal may only specify known properties,
                     but 'titel' does not exist... Did you mean to write 'title'?
类型不符   → TS2322  Type 'string' is not assignable to type 'number'.
联合值越界 → TS2322  Type '"middle"' is not assignable to type '"top" | "center" | "bottom"'.
```

## 一键导出：`pnpm export-config`

已经改了一堆配置的用户不用手抄。该命令以 **git 上的上游版本**为基准（自动依次尝试 `upstream/master` → `upstream/main` → `origin/master` → `origin/main`，可用 `--ref=` 指定，`--out=` 改输出目录），把当前 `src/config/` 与那一版逐字段比对，只导出改过的字段到 `overrides-export/`（已 gitignore）：

```
上游基准：upstream/master (453cc42)
导出目录：overrides-export

  已导出 siteConfig.ts（16 个顶层键）
  已导出 profileConfig.ts（3 个顶层键）
  ...
与上游一致、无需覆盖：sakuraConfig、licenseConfig、markdownConfig、...
```

三个要点：

- **写文件前自检** `deepMerge(上游默认, 覆盖) === 当前配置`，对不上就报出是哪个配置、差在哪，不会产出「看着像但装上不一样」的覆盖
- `navBarConfig.links` 里的 `LinkPreset` 按枚举名序列化（`LinkPreset.Home`），不是裸数字
- 深合并表达不了的「上游有、你删掉」的键会单独列出，提示手工处理

## 改动清单

### 新增

| 文件 | 作用 |
| --- | --- |
| `src/config/deepMerge.ts` | 合并语义。刻意不含 Vite 专有语法，可直接用 `node --experimental-strip-types` 单测 |
| `src/config/overrideLoader.ts` | `import.meta.glob` 加载 + 18 名白名单校验 |
| `scripts/export-config.mjs` | 一键导出命令 |
| `scripts/read-site-config.mjs` | Node 脚本的「覆盖优先、默认回退」取值助手 |
| `tests/config-overrides.test.ts` | 合并语义 7 条 |
| `tests/site-config-reader.test.ts` | 取值回退矩阵 8 条 |

### 修改

| 文件 | 改动 |
| --- | --- |
| `src/config/index.ts` | 改为合并适配器，18 个配置在导出前合并；`widgetConfigs` 聚合合并后的对象 |
| `src/types/config.ts` | 新增 `DeepPartial<T>`（数组分支短路，避免 `string[]` 退化成 `(string \| undefined)[]`） |
| `scripts/sync-content.js` | `contentMappings` 增加一条 `overrides → src/config/overrides`（复制同步；符号链接会让 Vite 把相对导入解析到内容仓库真实路径导致构建失败，未采用） |
| `.gitignore` | 忽略 `/src/config/overrides/` 与 `/overrides-export/` |
| `package.json` | 增加 `export-config` 脚本 |
| `docs/CONTENT_SEPARATION.md` | 新增「配置覆盖」章节，含完整迁移步骤 |
| `docs/CONTENT_REPOSITORY.md` | 目录结构与同步映射表补充 `overrides/` |

### 顺带修正的一致性问题

实现过程中发现 4 处会让覆盖**静默失效**或读到错值的地方，都在本 PR 内修掉：

**1. `src/utils/image-utils.ts` 绕过合并入口**

原来直接 `import { siteConfig } from "../config/siteConfig"`，导致 `imageOptimization` 的 `formats`/`quality`/`noReferrerDomains` 覆盖完全不生效。改为走 `../config`。改完之后全仓库已无绕过合并入口的直接 import。

**2. `SITE_LANG` 不跟随合并结果**

`siteConfig.ts` 里 `const SITE_LANG` 是独立常量，`index.ts` 原样 re-export。覆盖 `siteConfig.lang` 后 `SITE_LANG` 仍是上游默认值。改为从合并后的 `siteConfig.lang` 派生。

**3. 番剧数据脚本读不到覆盖**

`update-anime` / `update-bangumi` / `update-bilibili` 用正则扒 `siteConfig.ts` 源码取 `anime.mode`、`bangumi.userId`、`bilibili.vmid`。这些恰恰是纯个人值，放进 overrides 后不生效，而 `update-anime.mjs` 就在 `build` 脚本链的第一环。统一改走 `read-site-config.mjs`，按「覆盖 → 默认」顺序取值。

**4. 惰性正则在部分覆盖文件上会串块**（这条是真实 bug）

原来的 `/anime:\s*\{[\s\S]*?mode:\s*["']([^"']+)["']/` 在**完整的**默认配置上没问题，但覆盖文件是部分配置且键序任意。实测复现：

```ts
// overrides/siteConfig.ts
anime: {},
font: { mode: "system" },
```

番剧模式被读成 `"system"`，`update-anime.mjs` 直接跳过数据更新。改成花括号配平的块内取值，同时把 `coverMirror` / `useWebp` 也从全局匹配收敛进 `bilibili` 块内。

番剧模式的互斥性不受影响：`update-anime.mjs` 路由 + 子脚本各自自检，两边读同一个值，实测覆盖成 `bilibili` 后 `update-bangumi.mjs` 输出 `Detected current anime mode is "bilibili", skipping`。

## 验证

### 基础门禁

- `pnpm type-check` → 0 error（与本 PR 之前完全一致）
- `pnpm astro check` → 322 files，0 errors / 0 warnings / 0 hints
- `pnpm build` → 通过
- 新增 15 条测试全部通过
- `biome ci` 干净

### 机制验证

| 项 | 结果 |
| --- | --- |
| 无 `overrides/` 时 | 构建成功，`<title>` 为上游默认值，与现状一致 |
| 部分覆盖 | 只写 `banner.carousel.interval`，`enable`/`switchable` 保留默认 |
| 数组替换 | `banner.src.desktop` 覆盖为 1 张，结果就是 1 张；兄弟键 `mobile` 的 4 张不受影响 |
| 文件名拼错 | 构建期报错并列出 18 个合法名 |
| 漏写 `export default` | 构建期报错并给出正确写法 |
| 同步链路 | 造真实内容目录跑 `sync-content`，overrides 复制进代码仓库，合并结果正确 |
| 取值回退 | 只覆盖 `bilibili.vmid` 时，`coverMirror`/`useWebp`/`bangumi.userId` 全部正确回退默认 |

### 真实规模端到端验收

拿一个真实个人站点的配置（9 个分歧文件）走完整流程：

1. `pnpm export-config` → 自动生成 9 个最小化覆盖文件，自检通过
2. `git checkout <上游ref> -- src/config/` → 配置还原成上游原版
3. 覆盖文件落到 `src/config/overrides/`
4. `pnpm type-check` → **0 error**
5. 通过**真实的 Astro/Vite 合并路径**导出全部 18 个配置，与原始配置逐个深度比对 → **18/18 完全一致**
6. `pnpm build` → 站点标题、profile 链接、导航链接（与 profile 是不同的 B 站号，证明各配置独立合并）全部正确，默认 banner 残留 0 处

深合并能 100% 表达该站点的个人配置，没有出现「上游有、个人版删掉」这类无法表达的键。

一个能说明机制价值的观察：把基线从旧版本更新到最新上游后，`siteConfig` 需要覆盖的顶层键从 18 个降到 16 个——上游已经合入的字段自动从覆盖里消失。**跟上游跟得越紧，覆盖越小。**

## 迁移步骤

文档里写了完整流程，简述：

```bash
# 1. 导出个人配置（基准自动挑选，也可 --ref= 指定）
pnpm export-config

# 2. 放进内容仓库
cp overrides-export/*.ts ../Mizuki-Content/overrides/

# 3. 把代码仓库的配置还原成上游原版（收益来源：之后合并上游不再冲突）
git checkout upstream/master -- src/config/

# 4. 同步并校验
pnpm sync-content && pnpm type-check && pnpm build
```

内容仓库的 `trigger-build.yml` 需要把 `overrides/**` 加进 `paths`，否则只改配置不会触发重新构建。

**回滚**：覆盖机制是纯叠加的，删掉 `overrides/` 里的文件重新同步即可回到上游默认值；想完全退回旧方式，把个人配置写回 `src/config/*.ts`，代码不需要任何改动。

## 已知限制

已写进文档：

- **深合并表达不了「删除」**。只能改值或加字段，没法去掉上游默认里的某个键。`pnpm export-config` 遇到会明确报出来
- **评论语言不会自动跟随 `siteConfig.lang`**。`commentConfig.ts` 在模块顶层引用语言常量填充 Twikoo / Giscus 的 `lang`，覆盖 `siteConfig.lang` 时需要同时提供 `overrides/commentConfig.ts`
- **读取配置请统一走 `@/config` 入口**，直接 import 某个配置文件会绕过合并
- **开发服务器不监听内容仓库**，`src/config/overrides/` 在每次 dev/build 前从内容仓库复制而来；dev 运行中修改覆盖文件需要重启 `pnpm dev` 才会重新同步
- **`scripts/compress-fonts/` 暂不读取覆盖值**，该目录是独立的手动工具，不在 `pnpm build` 流程内

## 兼容性

- 不新增任何环境变量，完全搭载现有 `ENABLE_CONTENT_SYNC`
- 不创建 `overrides/` 目录时行为与现状完全一致，可按需渐进采用，逐个配置迁移
- 新增的两个测试文件没有加进 `package.json` 的 `test` 脚本，跟随现有约定（`tests/` 下多数文件也不在默认脚本里）



## 更新记录（2026-08-11）

- 已 rebase 到最新 master（含 #548），解决文档命令表冲突
- `overrides/` 同步由符号链接改为**复制**：覆盖文件是带相对导入的 TS 模块，junction 会被 Vite 解析到内容仓库真实路径，`../../types/config` 找不到导致 `astro build` 失败（CI 克隆内容仓库到 `./content` 时同样复现），原描述「Vite glob 能穿透」已修正
- 新增：内容仓库删除 `overrides/` 后，同步会清理代码仓库里的旧副本，避免失效配置残留
- 文档标注配置分离为实验性功能，精简了迁移步骤
