### PR TITLE
feat(i18n): auto-load Fancybox l10n matching siteConfig.lang

### DIFF
--- a/src/scripts/handlers/fancybox-handler.ts
+++ b/src/scripts/handlers/fancybox-handler.ts
@@ -8,6 +8,7 @@ import {
 	type FancyboxConfig,
 	getDefaultFancyboxConfig,
 } from "../core/swup-config";
+import { type FancyboxL10n, loadFancyboxL10n } from "../utils/fancybox-l10n";
 
 // Fancybox 模块类型
 type FancyboxType = any;
@@ -20,6 +21,7 @@ export class FancyboxHandler {
 	private Fancybox: FancyboxType | null = null;
 	private boundSelectors: string[] = [];
 	private initialized = false;
+	private l10n: FancyboxL10n | null = null;
 
 	/**
 	 * 初始化 Fancybox
@@ -32,7 +34,7 @@ export class FancyboxHandler {
 			return;
 		}
 
-		// 按需加载 Fancybox 模块
+		// 按需加载 Fancybox 模块及语言包
 		if (!this.Fancybox) {
 			await this.loadFancybox();
 		}
@@ -59,12 +61,13 @@ export class FancyboxHandler {
 	}
 
 	/**
-	 * 加载 Fancybox 模块和样式
+	 * 加载 Fancybox 模块和样式，并动态引入匹配的语言包
 	 */
 	private async loadFancybox(): Promise<void> {
 		const mod = await import("@fancyapps/ui");
 		this.Fancybox = mod.Fancybox;
 		await import("@fancyapps/ui/dist/fancybox/fancybox.css");
+		this.l10n = await loadFancyboxL10n();
 	}
 
 	/**
@@ -75,7 +78,11 @@ export class FancyboxHandler {
 			return;
 		}
 
-		const commonConfig = getDefaultFancyboxConfig();
+		const baseConfig = getDefaultFancyboxConfig();
+		const commonConfig: FancyboxConfig = {
+			...baseConfig,
+			...(this.l10n ? { l10n: this.l10n } : {}),
+		};
 
 		// 绑定相册/文章图片
 		this.Fancybox.bind(
@@ -116,6 +123,7 @@ export class FancyboxHandler {
 			Carousel: {
 				...carouselConfig,
 				transition: "slide",
+				...(this.l10n ? { l10n: this.l10n } : {}),
 				Lazyload: {
 					...(typeof lazyloadConfig === "object" ? lazyloadConfig : {}),
 					preload: 2,

--- a/src/scripts/utils/fancybox-l10n.ts
+++ b/src/scripts/utils/fancybox-l10n.ts
@@ -1,0 +1,70 @@
+/**
+ * Fancybox 语言包加载助手
+ * 根据站点或页面语言代码，规范化并动态加载对应的 Fancybox 语言包
+ */
+
+export type FancyboxL10n = Record<string, any>;
+
+/**
+ * 规范化语言代码为 Fancybox 语言包匹配格式
+ */
+export function normalizeLangCode(lang: string | null | undefined): string | null {
+	if (!lang) return null;
+	const normalized = lang.trim().replace(/-/g, "_");
+	const lower = normalized.toLowerCase();
+
+	if (
+		lower.startsWith("zh_tw") ||
+		lower.startsWith("zh_hk") ||
+		lower.startsWith("zh_hant")
+	) {
+		return "zh_TW";
+	}
+	if (lower.startsWith("zh")) {
+		return "zh_CN";
+	}
+	if (lower.startsWith("ja")) {
+		return "ja";
+	}
+	if (lower.startsWith("de")) {
+		return "de";
+	}
+	if (lower.startsWith("fr")) {
+		return "fr";
+	}
+	if (lower.startsWith("es")) {
+		return "es";
+	}
+	if (lower.startsWith("ru")) {
+		return "ru";
+	}
+	if (lower.startsWith("en")) {
+		return null; // Fancybox 默认界面语言即为英文
+	}
+	return normalized;
+}
+
+/**
+ * 动态加载对应的 Fancybox 语言包
+ */
+export async function loadFancyboxL10n(
+	lang?: string,
+): Promise<FancyboxL10n | null> {
+	const targetLang =
+		lang || (typeof document !== "undefined" ? document.documentElement.lang : "");
+	const langCode = normalizeLangCode(targetLang);
+
+	if (!langCode) {
+		return null;
+	}
+
+	try {
+		const l10nModule = await import(
+			/* @vite-ignore */ `@fancyapps/ui/dist/fancybox/l10n/${langCode}.js`
+		);
+		return l10nModule.default || l10nModule[langCode] || l10nModule;
+	} catch {
+		// 当对应语言包未提供或动态导入失败时，安全回退到默认语言
+		return null;
+	}
+}


### PR DESCRIPTION
Closes #552

## 背景

当前 Fancybox 图片灯箱界面的工具栏提示文本（如放大、缩小、1:1 还原、旋转、全屏、缩略图、自动播放、关闭等）默认固定为英文。即使站点语言（`siteConfig.lang`）配置为 `zh_CN`、`zh_TW` 或 `ja` 等非英语语言时，灯箱内部按钮依然显示英文提示。

本 PR 为 Fancybox 图片灯箱增加了**界面语言自动跟随**功能：在初始化 Fancybox 时，自动识别当前站点或页面的语言设定，并动态装载对应的 Fancybox 语言包。

## 方案与改动细节

### 1. 语言规范化与动态加载助手（`src/scripts/utils/fancybox-l10n.ts`）

- **语言代码规范化**：自动将各种写法（如 `zh-CN` / `zh_CN` / `zh-TW` / `zh_HK` / `ja` / `de` 等）规范化为对应语言包的匹配格式。
- **按需动态导入**：使用 `import(...)` 动态按需加载对应的语言包（`@fancyapps/ui/dist/fancybox/l10n/${langCode}.js`），避免将非当前语言包打包进静态资源，不增加无关页面的首屏体积。
- **安全降级机制**：当目标语言为英文（Fancybox 默认内置）或目标语言包未提供/加载失败时，优雅降级为默认英文，确保灯箱依然正常初始化。

### 2. Fancybox 处理器集成（`src/scripts/handlers/fancybox-handler.ts`）

- 在 `loadFancybox()` 异步加载灯箱主模块和样式时，同步加载对应的语言包。
- 将加载得到的语言配置（`l10n`）自动合并应用到 Fancybox 基础配置以及 `Carousel` 插件的配置中。

## 验证

- `pnpm run check` → 0 errors / 0 warnings / 0 hints
- `pnpm run build` → 打包通过
- **实际效果验证**：当站点语言设为 `zh_CN` 时，打开图片灯箱，工具栏各按钮（如放大、缩小、1:1 还原、左旋、右旋、全屏、缩略图、关闭等）均正确显示中文提示文本；切换至英文或其他未配置语言时，平滑降级为英文提示。
