### PR TITLE
fix(i18n): fix Fancybox l10n bundling under Vite

### DIFF
--- a/src/scripts/utils/fancybox-l10n.ts
+++ b/src/scripts/utils/fancybox-l10n.ts
@@ -6,43 +6,54 @@
 export type FancyboxL10n = Record<string, any>;
 
 /**
- * 规范化语言代码为 Fancybox 语言包匹配格式
+ * 规范化语言代码为 Fancybox 6 语言包文件名格式
  */
 export function normalizeLangCode(lang: string | null | undefined): string | null {
 	if (!lang) return null;
 	const normalized = lang.trim().replace(/-/g, "_");
 	const lower = normalized.toLowerCase();
 
-	if (
-		lower.startsWith("zh_tw") ||
-		lower.startsWith("zh_hk") ||
-		lower.startsWith("zh_hant")
-	) {
-		return "zh_TW";
-	}
 	if (lower.startsWith("zh")) {
 		return "zh_CN";
 	}
-	if (lower.startsWith("ja")) {
-		return "ja";
-	}
 	if (lower.startsWith("de")) {
-		return "de";
-	}
-	if (lower.startsWith("fr")) {
-		return "fr";
+		return "de_DE";
 	}
 	if (lower.startsWith("es")) {
-		return "es";
+		return "es_ES";
 	}
-	if (lower.startsWith("ru")) {
-		return "ru";
+	if (lower.startsWith("fr")) {
+		return "fr_FR";
+	}
+	if (lower.startsWith("it")) {
+		return "it_IT";
+	}
+	if (lower.startsWith("lv")) {
+		return "lv_LV";
+	}
+	if (lower.startsWith("tr")) {
+		return "tr_TR";
+	}
+	if (lower.startsWith("uk")) {
+		return "uk_UA";
 	}
 	if (lower.startsWith("en")) {
 		return null; // Fancybox 默认界面语言即为英文
 	}
 	return normalized;
 }
+
+// 显式声明静态分析导入，确保 Vite 构建打包时将语言包单独打包为生产环境可调用的 JS Chunk
+const l10nLoaders: Record<string, () => Promise<any>> = {
+	zh_CN: () => import("@fancyapps/ui/dist/fancybox/l10n/zh_CN.js"),
+	de_DE: () => import("@fancyapps/ui/dist/fancybox/l10n/de_DE.js"),
+	es_ES: () => import("@fancyapps/ui/dist/fancybox/l10n/es_ES.js"),
+	fr_FR: () => import("@fancyapps/ui/dist/fancybox/l10n/fr_FR.js"),
+	it_IT: () => import("@fancyapps/ui/dist/fancybox/l10n/it_IT.js"),
+	lv_LV: () => import("@fancyapps/ui/dist/fancybox/l10n/lv_LV.js"),
+	tr_TR: () => import("@fancyapps/ui/dist/fancybox/l10n/tr_TR.js"),
+	uk_UA: () => import("@fancyapps/ui/dist/fancybox/l10n/uk_UA.js"),
+};
 
 /**
  * 动态加载对应的 Fancybox 语言包
@@ -54,17 +65,15 @@ export async function loadFancyboxL10n(
 		lang || (typeof document !== "undefined" ? document.documentElement.lang : "");
 	const langCode = normalizeLangCode(targetLang);
 
-	if (!langCode) {
+	if (!langCode || !l10nLoaders[langCode]) {
 		return null;
 	}
 
 	try {
-		const l10nModule = await import(
-			/* @vite-ignore */ `@fancyapps/ui/dist/fancybox/l10n/${langCode}.js`
-		);
+		const l10nModule = await l10nLoaders[langCode]();
 		return l10nModule.default || l10nModule[langCode] || l10nModule;
 	} catch {
-		// 当对应语言包未提供或动态导入失败时，安全回退到默认语言
+		// 当对应语言包未提供或动态导入失败时，安全回退到默认英文
 		return null;
 	}
 }


### PR DESCRIPTION
Closes #554

## 背景与排查根因

在生产环境打包（`pnpm run build`）后部署线上站点时，Fancybox 界面语言无法正常显示为中文（回退为默认英文）。深入排查定位到了两处根因：

1. **Vite 打包分析忽略**：先前使用了 `/* @vite-ignore */ import(...)` 动态路径导入。Vite / Rolldown 在构建打包阶段会直接跳过该表达式的分析与打包，导致依赖包 `@fancyapps/ui` 里的语言包 JavaScript 脚本未包含在生成的静态 Chunk 产物中，线上运行时引发 404 并降级回英文。
2. **Fancybox 6 文件命名规范**：所使用的 `@fancyapps/ui@6.1.14` （Fancybox 6）内置语言包文件名带有地区后缀（如 `zh_CN.js`、`de_DE.js`、`es_ES.js`、`fr_FR.js` 等）。

## 修复方案

1. 使用显式导入映射字典（Explicit Dynamic Import Loaders）替换带 `@vite-ignore` 的字符串拼接路径。
2. 精准匹配 Fancybox 6 的语言包文件结构与导出。

```ts
const l10nLoaders: Record<string, () => Promise<any>> = {
	zh_CN: () => import("@fancyapps/ui/dist/fancybox/l10n/zh_CN.js"),
	de_DE: () => import("@fancyapps/ui/dist/fancybox/l10n/de_DE.js"),
	es_ES: () => import("@fancyapps/ui/dist/fancybox/l10n/es_ES.js"),
	fr_FR: () => import("@fancyapps/ui/dist/fancybox/l10n/fr_FR.js"),
	it_IT: () => import("@fancyapps/ui/dist/fancybox/l10n/it_IT.js"),
	lv_LV: () => import("@fancyapps/ui/dist/fancybox/l10n/lv_LV.js"),
	tr_TR: () => import("@fancyapps/ui/dist/fancybox/l10n/tr_TR.js"),
	uk_UA: () => import("@fancyapps/ui/dist/fancybox/l10n/uk_UA.js"),
};
```

此改动让 Vite 在构建打包时能够自动识别并将各语言包提取打包为独立的 Chunk，在运行时精准异步加载。

## 验证

- `pnpm run check` → 0 errors / 0 warnings / 0 hints
- `pnpm run build` → 成功生成包含 `zh_CN` 语言包的生产 Chunk
- 验证线上生产环境构建部署后，Fancybox 工具栏提示正确显示为中文
