### PR TITLE
docs: fix broken Star History chart in READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -330,6 +330,6 @@ Mizuki-Content/
 
 ## ⭐ Star History
 
-## [![Star History Chart](https://api.star-history.com/svg?repos=LyraVoid/Mizuki&type=Date)](https://star-history.com/#LyraVoid/Mizuki&Date)
+## [![Star History Chart](https://star-history.dera.page/svg?repos=LyraVoid/Mizuki&type=Date)](https://star-history.dera.page/#LyraVoid/Mizuki&Date)
 
 ⭐ このプロジェクトが役立つと思ったら、スターを付けることを検討してください！

--- a/README.md
+++ b/README.md
@@ -339,6 +339,6 @@ Thanks to all contributors for their contributions to this project. If you have 
 
 ## ⭐ Star History
 
-## [![Star History Chart](https://api.star-history.com/svg?repos=LyraVoid/Mizuki&type=Date)](https://star-history.com/#LyraVoid/Mizuki&Date)
+## [![Star History Chart](https://star-history.dera.page/svg?repos=LyraVoid/Mizuki&type=Date)](https://star-history.dera.page/#LyraVoid/Mizuki&Date)
 
 ⭐ If you find this project helpful, please consider giving it a star!

--- a/README.tw.md
+++ b/README.tw.md
@@ -330,6 +330,6 @@ Mizuki-Content/
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=LyraVoid/Mizuki&type=Date)](https://star-history.com/#LyraVoid/Mizuki&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=LyraVoid/Mizuki&type=Date)](https://star-history.dera.page/#LyraVoid/Mizuki&Date)
 
 ⭐ 如果您覺得這個專案有幫助，請考慮給它一個星標！

--- a/README.zh.md
+++ b/README.zh.md
@@ -335,6 +335,6 @@ Markdown 增强功能的部分实现基于 [Firefly](https://github.com/CuteLeaf
 
 ## ⭐ Star History
 
-## [![Star History Chart](https://api.star-history.com/svg?repos=LyraVoid/Mizuki&type=Date)](https://star-history.com/#LyraVoid/Mizuki&Date)
+## [![Star History Chart](https://star-history.dera.page/svg?repos=LyraVoid/Mizuki&type=Date)](https://star-history.dera.page/#LyraVoid/Mizuki&Date)
 
 ⭐ 如果您觉得这个项目有帮助，请考虑给它一个星标!


### PR DESCRIPTION
The Star History chart no longer renders because the service it relied on is broken due to GitHub stargazer API restrictions. This change points the chart to a working alternative so visitors can again see the project's stargazer history. The badge and all other links are left untouched.