### PR TITLE
fix(anime): read fetchOnDev from siteConfig in getAnimeSourceConfigs

### DIFF
--- a/src/pages/anime.astro
+++ b/src/pages/anime.astro
@@ -25,7 +25,7 @@ const hasRightSidebars =
 		0;
 
 const ANIME_MODE = siteConfig.anime?.mode || "bangumi";
-const sourceConfigs = getAnimeSourceConfigs();
+const sourceConfigs = getAnimeSourceConfigs(siteConfig);
 const { animeList, currentConfig } = getAnimeList(ANIME_MODE, sourceConfigs);
 
 let emptyDescription = "";

--- a/src/utils/anime-data.ts
+++ b/src/utils/anime-data.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import type { SiteConfig } from "../types/config";
+
 import localAnimeList from "../data/anime";
 import I18nKey from "../i18n/i18nKey";
 import { i18n } from "../i18n/translation";
@@ -73,7 +75,9 @@ export function loadAnimeData(filename: string): AnimeItem[] {
 	}
 }
 
-export function getAnimeSourceConfigs(): Record<string, AnimeSourceConfig> {
+export function getAnimeSourceConfigs(
+	siteConfig: SiteConfig,
+): Record<string, AnimeSourceConfig> {
 	return {
 		local: {
 			type: "local",
@@ -82,13 +86,13 @@ export function getAnimeSourceConfigs(): Record<string, AnimeSourceConfig> {
 		bilibili: {
 			type: "json",
 			filename: "bilibili-data.json",
-			fetchOnDev: undefined,
+			fetchOnDev: siteConfig.bilibili?.fetchOnDev,
 			emptyDescription: i18n(I18nKey.animeEmptyBilibili),
 		},
 		bangumi: {
 			type: "json",
 			filename: "bangumi-data.json",
-			fetchOnDev: undefined,
+			fetchOnDev: siteConfig.bangumi?.fetchOnDev,
 			emptyDescription: i18n(I18nKey.animeEmptyBangumi),
 		},
 	};


### PR DESCRIPTION
> ⚠️ 说明：本内容由 AI 辅助生成（assisted by AI）。

## 摘要
修复 `siteConfig.bilibili.fetchOnDev` / `siteConfig.bangumi.fetchOnDev` 配置不生效的问题：
`getAnimeSourceConfigs()` 此前将 `fetchOnDev` 硬编码为 `undefined`，导致 dev 模式下
始终跳过番剧数据加载（`[Dev] Skipping ... data load (fetchOnDev is off).`）。

## 变更
- `src/utils/anime-data.ts`：`getAnimeSourceConfigs(siteConfig)` 接收 `SiteConfig`，
  从 `siteConfig.bilibili?.fetchOnDev` / `siteConfig.bangumi?.fetchOnDev` 读取配置
- `src/pages/anime.astro`：调用处传入 `siteConfig`

## 测试
- `pnpm type-check` 通过（`tsc --noEmit` 无错误）
- `pnpm astro build` 通过（26 页构建成功）

Closes #561
